### PR TITLE
do not traceback on concurent runs

### DIFF
--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -52,6 +52,7 @@ GNU General Public License for more details.
 import inspect
 import itertools
 import logging
+import sys
 import usb
 
 from docopt import docopt
@@ -119,6 +120,7 @@ def _device_get_status(dev, num):
             print('{:<18}    {:>10}  {:<3}'.format(k, v, u))
     except usb.core.USBError as e:
         LOGGER.error(str(e))
+        sys.exit(2)
     finally:
         dev.disconnect()
     print('')

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -52,6 +52,7 @@ GNU General Public License for more details.
 import inspect
 import itertools
 import logging
+import usb
 
 from docopt import docopt
 
@@ -116,6 +117,8 @@ def _device_get_status(dev, num):
         status = dev.get_status()
         for k, v, u in status:
             print('{:<18}    {:>10}  {:<3}'.format(k, v, u))
+    except usb.core.USBError as e:
+        LOGGER.error(str(e))
     finally:
         dev.disconnect()
     print('')


### PR DESCRIPTION
When you run two concurrent `liquidctl status -v` you get traceback with an error. This will just print the error.

Tested only with python3