### PR TITLE
Support monitoring of Corsair HXi and RMi PSUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Firmware version           4.0.2
 
 | Family | Documentation | Notes |
 | --- | --- | --- |
+| Corsair HX750i, HX850i, HX1000i, HX1200i | [documentation](docs/corsair-hxi-rmi.md) | <sup>1</sup> |
+| Corsair RM650i, RM750i, RM850i, RM1000i | [documentation](docs/corsair-hxi-rmi.md) | <sup>1</sup> |
 | NZXT Grid+ V3 | [documentation](docs/nzxt-smart-device.md#experimental-support-for-the-grid-v3) | <sup>1</sup> |
 | NZXT Smart Device | [documentation](docs/nzxt-smart-device.md) | |
 

--- a/docs/corsair-hxi-rmi.md
+++ b/docs/corsair-hxi-rmi.md
@@ -18,4 +18,21 @@ The PSU is able to report monitoring data about its own hardware and basic elect
 
 ```
 # liquidctl status
+Device 0, Corsair RM650i (experimental)
+Current uptime                        3:43:54
+Total uptime                 9 days, 11:43:54
+Temperature 1                            50.0  °C
+Temperature 2                            40.8  °C
+Fan speed                                   0  rpm
+Input voltage                          230.00  V
+Total power                            110.00  W
++12V output voltage                     12.12  V
++12V output current                      7.75  A
++12V output power                       92.00  W
++5V output voltage                       4.97  V
++5V output current                       2.88  A
++5V output power                        14.00  W
++3.3V output voltage                     3.33  V
++3.3V output current                     1.56  A
++3.3V output power                       5.00  W
 ```

--- a/docs/corsair-hxi-rmi.md
+++ b/docs/corsair-hxi-rmi.md
@@ -4,9 +4,7 @@
 
 ## Initialization
 
-These devices should operate and be accessible without any explicit initialization.
-
-However, the driver is still under development and future versions could implement additional features that might depend on device state.  Because of this, it is still recommended to call `initialize` after booting the system.
+It is necessary to initialize the device it has been powered on.
 
 
 ```

--- a/docs/corsair-hxi-rmi.md
+++ b/docs/corsair-hxi-rmi.md
@@ -1,0 +1,23 @@
+# Corsair HXi and RMi series PSUs
+
+**Support for these devices is still experimental.**
+
+## Initialization
+
+These devices should operate and be accessible without any explicit initialization.
+
+However, the driver is still under development and future versions could implement additional features that might depend on device state.  Because of this, it is still recommended to call `initialize` after booting the system.
+
+
+```
+# liquidctl initialize
+```
+
+
+## Monitoring
+
+The PSU is able to report monitoring data about its own hardware and basic electrical variables for the input and output sides.
+
+```
+# liquidctl status
+```

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -63,6 +63,7 @@ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 """
 
+import datetime
 import inspect
 import itertools
 import logging
@@ -92,6 +93,15 @@ _OPTIONS_TO_FORWARD = [
     '--alert-threshold',
     '--alert-color',
 ]
+
+# custom number formats for values of select units
+_VALUE_FORMATS = {
+    '°C' : '.1f',
+    'rpm' : '.0f',
+    'V' : '.2f',
+    'A' : '.2f',
+    'W' : '.2f'
+}
 
 
 DRIVERS = [
@@ -168,7 +178,11 @@ def _device_get_status(dev, num, **kwargs):
     try:
         status = dev.get_status(**kwargs)
         for k, v, u in status:
-            print('{:<18}    {:>10}  {:<3}'.format(k, v, u))
+            if isinstance(v, datetime.timedelta):
+                v = str(v)
+                u = ''
+            valfmt = _VALUE_FORMATS.get(u, '')
+            print('{:<18}    {:>20{valfmt}}  {:<3}'.format(k, v, u, valfmt=valfmt))
     finally:
         dev.disconnect(**kwargs)
     print('')

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -177,12 +177,20 @@ def _device_get_status(dev, num, **kwargs):
     dev.connect(**kwargs)
     try:
         status = dev.get_status(**kwargs)
+        tmp = []
+        kcols, vcols, ucols = 0, 0, 0
         for k, v, u in status:
             if isinstance(v, datetime.timedelta):
                 v = str(v)
                 u = ''
-            valfmt = _VALUE_FORMATS.get(u, '')
-            print('{:<18}    {:>20{valfmt}}  {:<3}'.format(k, v, u, valfmt=valfmt))
+            else:
+                valfmt = _VALUE_FORMATS.get(u, '')
+                v = '{:{}}'.format(v, valfmt)
+            kcols = max(kcols, len(k))
+            vcols = max(vcols, len(v))
+            tmp.append((k, v, u))
+        for k, v, u in tmp:
+            print('{:<{}}    {:>{}}  {}'.format(k, kcols, v, vcols, u))
     finally:
         dev.disconnect(**kwargs)
     print('')

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -73,6 +73,7 @@ from docopt import docopt
 import liquidctl.driver.asetek
 import liquidctl.driver.kraken_two
 import liquidctl.driver.nzxt_smart_device
+import liquidctl.driver.corsair_hid_psu
 import liquidctl.driver.usb
 import liquidctl.util
 from liquidctl.util import color_from_str
@@ -97,6 +98,7 @@ DRIVERS = [
     liquidctl.driver.asetek.AsetekDriver,
     liquidctl.driver.asetek.CorsairAsetekDriver,
     liquidctl.driver.asetek.LegacyAsetekDriver,
+    liquidctl.driver.corsair_hid_psu.CorsairHidPsuDriver,
     liquidctl.driver.kraken_two.KrakenTwoDriver,
     liquidctl.driver.nzxt_smart_device.NzxtSmartDeviceDriver,
 ]

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -224,7 +224,7 @@ def main():
     elif args['--verbose']:
         logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     else:
-        logging.basicConfig(level=logging.WARNING, format='%(message)s')
+        logging.basicConfig(level=logging.WARNING, format='%(levelname)s: %(message)s')
         sys.tracebacklimit = 0
 
     frwd = _get_options_to_forward(args)

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -11,9 +11,9 @@ Supported devices
 Supported features
 ------------------
 
- - [ ] general device monitoring
- - [ ] electrical input monitoring
- - [ ] electrical output monitoring
+ - [✓] general device monitoring
+ - [✓] electrical input monitoring
+ - [✓] electrical output monitoring
  - [ ] fan control
  - [ ] 12V multirail configuration
 
@@ -47,10 +47,35 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
 
+from datetime import timedelta
+
 from liquidctl.driver.usb import UsbHidDriver
 
 
 LOGGER = logging.getLogger(__name__)
+
+_READ_LENGTH = 64
+_WRITE_LENGTH = 64
+
+_OP_WRITE = 0x02
+_OP_READ = 0x03
+
+_REG_OUT_SEL = 0x00
+_REG_POW_ON = 0xd1
+_REG_UPTIME = 0xd2
+_REG_TEMP1 = 0x8d
+_REG_TEMP2 = 0x8e
+_REG_FAN_RPM = 0x90
+_REG_INP_VOLT = 0x88
+_REG_INP_POWR = 0xee
+_REG_OUT_VOLT = 0x8b
+_REG_OUT_CURR = 0x8c
+_REG_OUT_POWR = 0x96
+
+_RAIL_12V = 0x0
+_RAIL_5V = 0x1
+_RAIL_3P3V = 0x2
+_RAIL_NAMES = {_RAIL_12V : '+12V', _RAIL_5V : '+5V', _RAIL_3P3V : '+3.3V'}
 
 
 class CorsairHidPsuDriver(UsbHidDriver):
@@ -76,4 +101,69 @@ class CorsairHidPsuDriver(UsbHidDriver):
 
         Returns a list of `(property, value, unit)` tuples.
         """
-        return []
+        self._write(_OP_WRITE, _REG_OUT_SEL)  # clear any previous output selection
+        status = [
+            ('Current uptime', timedelta(seconds=self._get_int(_REG_UPTIME, 32)), ''),
+            ('Total uptime', timedelta(seconds=self._get_int(_REG_POW_ON, 32)), ''),
+            ('Temperature 1', self._get_float(_REG_TEMP1), '°C'),
+            ('Temperature 2', self._get_float(_REG_TEMP1), '°C'),
+            ('Fan speed', self._get_float(_REG_FAN_RPM), 'rpm'),
+            ('Input voltage', self._get_float(_REG_INP_VOLT), 'V'),
+            ('Total power', self._get_float(_REG_INP_POWR), 'W')
+        ]
+        for rail in [_RAIL_12V, _RAIL_5V, _RAIL_3P3V]:
+            key_prefix = '{} output'.format(_RAIL_NAMES[rail])
+            self._write(_OP_WRITE, _REG_OUT_SEL, value=rail)
+            status.append(('{} voltage'.format(key_prefix), self._get_float(_REG_OUT_VOLT), 'V'))
+            status.append(('{} current'.format(key_prefix), self._get_float(_REG_OUT_CURR), 'A'))
+            status.append(('{} power'.format(key_prefix), self._get_float(_REG_OUT_POWR), 'W'))
+        # note: we don't clear the output selection
+        self.device.release()
+        return status
+
+    def _write(self, opcode, register, value=0):
+        msg = [0x0] * _WRITE_LENGTH
+        msg[0], msg[1], msg[2] = (opcode, register, value)
+        LOGGER.debug('write %s', ' '.join(format(i, '02x') for i in msg))
+        self.device.write(msg)
+
+    def _read(self):
+        msg = self.device.read(_READ_LENGTH)
+        LOGGER.debug('received %s', ' '.join(format(i, '02x') for i in msg))
+        return msg
+
+    def _get_int(self, register, size, byteorder='little'):
+        """Read integer with `size` bits from `register`."""
+        self._write(_OP_READ, register)
+        msg = self._read()
+        if (size >> 3) % 8:
+            raise NotImplementedError('Cannot read partial bytes yet')
+        ubound = 2 + (size >> 3)
+        return int.from_bytes(msg[2:ubound], byteorder=byteorder)
+
+    def _get_float(self, register):
+        """Read 2-byte minifloat from `register`.
+
+        A custom format is used by these devices which deviates from the IEEE
+        754 binary16 half float in many ways: the fraction is stored in the
+        lower 11 bits, in two's-complement; the exponent is is stored in the
+        upper 5 bits, also in two's-complement.[1]
+
+             15              11                                           0
+           | E | E | E | E | E | F | F | F | F | F | F | F | F | F | F | F |
+
+        [1] Both corsaiRMi and OpenCorsairLink (OCL) implement the convertion
+        between this custom format and a double, but with slight differences.
+        The git histories suggests that OCL's implementation was more
+        thoroughly tested and revised, and thus is the basis for this method
+        (see: convert_bytes_double as of OCL commit 99e1d72fa5a0).
+        """
+        short = self._get_int(register, 16, byteorder='little')
+        exp = short >> 11
+        fra = short & 0x7ff
+        if exp > 15:
+            exp = exp - 32
+        if fra > 1023:
+            fra = fra - 2048
+        # note: unlike OpenCorsairLink we don't round the last binary digit
+        return fra * 2**exp

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -124,11 +124,7 @@ class CorsairHidPsuDriver(UsbHidDriver):
         return msg
 
     def _exec(self, writebit, command, data=None):
-        if not writebit in WriteBit:
-            raise ValueError('Unknown value bit: {}'.format(writebit))
-        if not command in CMD:
-            raise ValueError('Unknown command code: {}'.format(command))
-        self._write([_SLAVE_ADDRESS | writebit, command] + (data or []))
+        self._write([_SLAVE_ADDRESS | WriteBit(writebit), CMD(command)] + (data or []))
         return self._read()
 
     def _get_float(self, command):

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -100,7 +100,9 @@ class CorsairHidPsuDriver(UsbHidDriver):
 
         Returns a list of `(property, value, unit)` tuples.
         """
-        self._exec(WriteBit.WRITE, CMD.PAGE, [0])
+        ret = self._exec(WriteBit.WRITE, CMD.PAGE, [0])
+        if ret[1] == 0xfe:
+            LOGGER.warning('Possibly uninitialized device')
         status = [
             ('Current uptime', self._get_timedelta(_CORSAIR_READ_UPTIME), ''),
             ('Total uptime', self._get_timedelta(_CORSAIR_READ_TOTAL_UPTIME), ''),

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -152,9 +152,9 @@ class CorsairHidPsuDriver(UsbHidDriver):
 
         [1] Both corsaiRMi and OpenCorsairLink (OCL) implement the convertion
         between this custom format and a double, but with slight differences.
-        The git histories suggests that OCL's implementation was more
-        thoroughly tested and revised, and thus is the basis for this method
-        (see: convert_bytes_double as of OCL commit 99e1d72fa5a0).
+        The git histories suggest that OCL's implementation was more thoroughly
+        tested and revised, and thus that was the basis for this method (see:
+        convert_bytes_double as of OCL commit 99e1d72fa5a0).
         """
         short = self._get_int(register, 16, byteorder='little')
         exp = short >> 11

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -18,13 +18,13 @@ Supported features
  - [ ] 12V multirail configuration
 
 
-Port of corsairRMi.  Incorporates or uses as reference work by notaz and
-realies, under the terms of the BSD 3-Clause license.
+Port of corsaiRMi: incorporates or uses as reference work by notaz and realies,
+under the terms of the BSD 3-Clause license.
 
 Incorporates or uses as reference work by Sean Nelson, under the terms of the
 GNU General Public License.
 
-corsairRMi
+corsaiRMi
 Copyright (c) notaz, 2016
 
 liquidctl driver for Corsair HID PSUs

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -1,0 +1,82 @@
+"""liquidctl driver for Corsair HID PSUs.
+
+
+Supported devices
+-----------------
+
+ - Corsair RMi (RM550i, RM650i, RM750i, RM850i or RM1000i)
+ - Corsair HXi (HX550i, HX650i, HX750i, HX850i, HX1000i or HX1200i)
+
+
+Supported features
+------------------
+
+ - [ ] general device monitoring
+ - [ ] electrical input monitoring
+ - [ ] electrical output monitoring
+ - [ ] fan control
+ - [ ] 12V multirail configuration
+
+
+Port of corsairRMi.  Incorporates or uses as reference work by notaz and
+realies, under the terms of the BSD 3-Clause license.
+
+Incorporates or uses as reference work by Sean Nelson, under the terms of the
+GNU General Public License.
+
+corsairRMi
+Copyright (c) notaz, 2016
+
+liquidctl driver for Corsair HID PSUs
+Copyright (C) 2019  Jonas Malaco
+Copyright (C) 2019  each contribution's author
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import logging
+
+from liquidctl.driver.usb import UsbHidDriver
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CorsairHidPsuDriver(UsbHidDriver):
+    """liquidctl driver for Corsair HID PSUs."""
+
+    SUPPORTED_DEVICES = [
+        (0x1b1c, 0x1c09, None, 'Corsair RM550i (experimental)', {}),
+        (0x1b1c, 0x1c0a, None, 'Corsair RM650i (experimental)', {}),
+        (0x1b1c, 0x1c0b, None, 'Corsair RM750i (experimental)', {}),
+        (0x1b1c, 0x1c0c, None, 'Corsair RM850i (experimental)', {}),
+        (0x1b1c, 0x1c0d, None, 'Corsair RM1000i (experimental)', {}),
+        (0x1b1c, 0x1c03, None, 'Corsair HX550i (experimental)', {}),
+        (0x1b1c, 0x1c04, None, 'Corsair HX650i (experimental)', {}),
+        (0x1b1c, 0x1c05, None, 'Corsair HX750i (experimental)', {}),
+        (0x1b1c, 0x1c06, None, 'Corsair HX850i (experimental)', {}),
+        (0x1b1c, 0x1c07, None, 'Corsair HX1000i (experimental)', {}),
+        (0x1b1c, 0x1c08, None, 'Corsair HX1200i (experimental)', {}),
+    ]
+
+    def initialize(self, **kwargs):
+        """Initialize the device."""
+        pass
+
+    def get_status(self, **kwargs):
+        """Get a status report.
+
+        Returns a list of `(property, value, unit)` tuples.
+        """
+        return []

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -113,6 +113,7 @@ class CorsairHidPsuDriver(UsbHidDriver):
         for rail in [_RAIL_12V, _RAIL_5V, _RAIL_3P3V]:
             key_prefix = '{} output'.format(_RAIL_NAMES[rail])
             self._write(_OP_WRITE, _REG_OUT_SEL, value=rail)
+            self._read()
             status.append(('{} voltage'.format(key_prefix), self._get_float(_REG_OUT_VOLT), 'V'))
             status.append(('{} current'.format(key_prefix), self._get_float(_REG_OUT_CURR), 'A'))
             status.append(('{} power'.format(key_prefix), self._get_float(_REG_OUT_POWR), 'W'))

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -84,8 +84,16 @@ class CorsairHidPsuDriver(UsbHidDriver):
     ]
 
     def initialize(self, **kwargs):
-        """Initialize the device."""
-        pass
+        """Initialize the device.
+
+        Necessary to receive non-zero value responses from the device.
+
+        Note: replies before calling this function appear to follow the
+        pattern <address> <cte 0xfe> <zero> <zero> <padding...>.
+        """
+        self._write([0xfe, 0x03])  # not well understood
+        self._read()
+        self.device.release()
 
     def get_status(self, **kwargs):
         """Get a status report.

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -103,11 +103,11 @@ class CorsairHidPsuDriver(UsbHidDriver):
             ('Total power', self._get_float(_CORSAIR_READ_INPUT_POWER), 'W')
         ]
         for rail in [_RAIL_12V, _RAIL_5V, _RAIL_3P3V]:
-            key_prefix = '{} output'.format(_RAIL_NAMES[rail])
+            name = _RAIL_NAMES[rail]
             self._exec(WriteBit.WRITE, CMD.PAGE, [rail])
-            status.append(('{} voltage'.format(key_prefix), self._get_float(CMD.READ_VOUT), 'V'))
-            status.append(('{} current'.format(key_prefix), self._get_float(CMD.READ_IOUT), 'A'))
-            status.append(('{} power'.format(key_prefix), self._get_float(CMD.READ_POUT), 'W'))
+            status.append((f'{name} output voltage', self._get_float(CMD.READ_VOUT), 'V'))
+            status.append((f'{name} output current', self._get_float(CMD.READ_IOUT), 'A'))
+            status.append((f'{name} output power', self._get_float(CMD.READ_POUT), 'W'))
         self._exec(WriteBit.WRITE, CMD.PAGE, [0])
         self.device.release()
         return status

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -4,8 +4,8 @@
 Supported devices
 -----------------
 
- - Corsair RMi (RM550i, RM650i, RM750i, RM850i or RM1000i)
- - Corsair HXi (HX550i, HX650i, HX750i, HX850i, HX1000i or HX1200i)
+ - Corsair HXi (HX750i, HX850i, HX1000i and HX1200i)
+ - Corsair RMi (RM650i, RM750i, RM850i and RM1000i)
 
 
 Supported features
@@ -57,17 +57,14 @@ class CorsairHidPsuDriver(UsbHidDriver):
     """liquidctl driver for Corsair HID PSUs."""
 
     SUPPORTED_DEVICES = [
-        (0x1b1c, 0x1c09, None, 'Corsair RM550i (experimental)', {}),
-        (0x1b1c, 0x1c0a, None, 'Corsair RM650i (experimental)', {}),
-        (0x1b1c, 0x1c0b, None, 'Corsair RM750i (experimental)', {}),
-        (0x1b1c, 0x1c0c, None, 'Corsair RM850i (experimental)', {}),
-        (0x1b1c, 0x1c0d, None, 'Corsair RM1000i (experimental)', {}),
-        (0x1b1c, 0x1c03, None, 'Corsair HX550i (experimental)', {}),
-        (0x1b1c, 0x1c04, None, 'Corsair HX650i (experimental)', {}),
         (0x1b1c, 0x1c05, None, 'Corsair HX750i (experimental)', {}),
         (0x1b1c, 0x1c06, None, 'Corsair HX850i (experimental)', {}),
         (0x1b1c, 0x1c07, None, 'Corsair HX1000i (experimental)', {}),
         (0x1b1c, 0x1c08, None, 'Corsair HX1200i (experimental)', {}),
+        (0x1b1c, 0x1c0a, None, 'Corsair RM650i (experimental)', {}),
+        (0x1b1c, 0x1c0b, None, 'Corsair RM750i (experimental)', {}),
+        (0x1b1c, 0x1c0c, None, 'Corsair RM850i (experimental)', {}),
+        (0x1b1c, 0x1c0d, None, 'Corsair RM1000i (experimental)', {}),
     ]
 
     def initialize(self, **kwargs):

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -142,4 +142,4 @@ class CorsairHidPsuDriver(UsbHidDriver):
 
     def _get_float(self, command):
         """Get float value with `command`."""
-        return linear_to_float(self._exec(WriteBit.READ, command), pos=2)
+        return linear_to_float(self._exec(WriteBit.READ, command)[2:])

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -105,7 +105,6 @@ class CorsairHidPsuDriver(UsbHidDriver):
         for rail in [_RAIL_12V, _RAIL_5V, _RAIL_3P3V]:
             key_prefix = '{} output'.format(_RAIL_NAMES[rail])
             self._exec(WriteBit.WRITE, CMD.PAGE, [rail])
-            self._read()
             status.append(('{} voltage'.format(key_prefix), self._get_float(CMD.READ_VOUT), 'V'))
             status.append(('{} current'.format(key_prefix), self._get_float(CMD.READ_IOUT), 'A'))
             status.append(('{} power'.format(key_prefix), self._get_float(CMD.READ_POUT), 'W'))

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -101,7 +101,6 @@ class CorsairHidPsuDriver(UsbHidDriver):
 
         Returns a list of `(property, value, unit)` tuples.
         """
-        self._write(_OP_WRITE, _REG_OUT_SEL)  # clear any previous output selection
         status = [
             ('Current uptime', timedelta(seconds=self._get_int(_REG_UPTIME, 32)), ''),
             ('Total uptime', timedelta(seconds=self._get_int(_REG_POW_ON, 32)), ''),
@@ -117,7 +116,6 @@ class CorsairHidPsuDriver(UsbHidDriver):
             status.append(('{} voltage'.format(key_prefix), self._get_float(_REG_OUT_VOLT), 'V'))
             status.append(('{} current'.format(key_prefix), self._get_float(_REG_OUT_CURR), 'A'))
             status.append(('{} power'.format(key_prefix), self._get_float(_REG_OUT_POWR), 'W'))
-        # note: we don't clear the output selection
         self.device.release()
         return status
 

--- a/liquidctl/pmbus.py
+++ b/liquidctl/pmbus.py
@@ -1,0 +1,91 @@
+"""Constants and methods for interfacing with PMBus compliant devices.
+
+References:
+
+White, Robert V; 2010.  Power Systems Management Protocol Specification.  Part
+II – Command Language.  Revision 1.2.
+http://pmbus.org/Assets/PDFS/Public/PMBus_Specification_Part_II_Rev_1-2_20100906.pdf
+
+White, Robert V; 2005.  Using the PMBus Protocol.
+http://pmbus.org/Assets/Present/Using_The_PMBus_20051012.pdf
+
+Copyright (C) 2019  Jonas Malaco
+Copyright (C) 2019  each contribution's author
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from enum import IntEnum, IntFlag, unique
+
+@unique
+class WriteBit(IntFlag):
+    WRITE = 0x00
+    READ = 0x01
+
+@unique
+class CommandCode(IntEnum):
+    """Incomplete enumeration of the PMBus command codes."""
+
+    PAGE = 0x00
+
+    READ_EIN = 0x86
+    READ_EOUT = 0x87
+    READ_VIN = 0x88
+    READ_IIN = 0x89
+    READ_VCAP = 0x8a
+    READ_VOUT = 0x8b
+    READ_IOUT = 0x8c
+    READ_TEMPERATURE_1 = 0x8d
+    READ_TEMPERATURE_2 = 0x8e
+    READ_TEMPERATURE_3 = 0x8f
+    READ_FAN_SPEED_1 = 0x90
+    READ_FAN_SPEED_2 = 0x91
+    READ_FAN_SPEED_3 = 0x92
+    READ_FAN_SPEED_4 = 0x93
+    READ_DUTY_CYCLE = 0x94
+    READ_FREQUENCY = 0x95
+    READ_POUT = 0x96
+    READ_PIN = 0x97
+    READ_PMBUS_REVISON = 0x98
+    MFR_ID = 0x99
+    MFR_MODEL = 0x9a
+    MFR_REVISION = 0x9b
+    MFR_LOCATION = 0x9c
+    MFR_DATE = 0x9d
+    MFR_SERIAL = 0x9e
+
+    MFR_SPECIFIC_01 = 0xd1
+    MFR_SPECIFIC_02 = 0xd2
+    MFR_SPECIFIC_30 = 0xee
+
+
+def linear_to_float(bytes, pos=0):
+    """Read PMBus Linear Data Format 2-byte minifloat.
+
+    In the Linear Data Format the fraction is stored in the lower 11 bits, in
+    two's-complement, and the exponent is is stored in the upper 5 bits, also
+    in two's-complement.  Per the SMBus specification, the lowest order byte is
+    sent first (endianess is little).
+
+    >>> linear_to_float([0x67, 0xe3])
+    54.4375
+    """
+    tmp = int.from_bytes(bytes[pos:pos + 2], byteorder='little')
+    exp = tmp >> 11
+    fra = tmp & 0x7ff
+    if exp > 15:
+        exp = exp - 32
+    if fra > 1023:
+        fra = fra - 2048
+    return fra * 2**exp

--- a/liquidctl/pmbus.py
+++ b/liquidctl/pmbus.py
@@ -39,6 +39,11 @@ class CommandCode(IntEnum):
 
     PAGE = 0x00
 
+    PAGE_PLUS_WRITE = 0x05
+    PAGE_PLUS_READ = 0x06
+
+    VOUT_MODE = 0x20
+
     READ_EIN = 0x86
     READ_EOUT = 0x87
     READ_VIN = 0x88
@@ -67,7 +72,9 @@ class CommandCode(IntEnum):
 
     MFR_SPECIFIC_01 = 0xd1
     MFR_SPECIFIC_02 = 0xd2
+    MFR_SPECIFIC_12 = 0xdc
     MFR_SPECIFIC_30 = 0xee
+    MFR_SPECIFIC_44 = 0xfc
 
 
 def linear_to_float(bytes, vout_exp=None):

--- a/liquidctl/pmbus.py
+++ b/liquidctl/pmbus.py
@@ -39,6 +39,8 @@ class CommandCode(IntEnum):
 
     PAGE = 0x00
 
+    CLEAR_FAULTS = 0x03
+
     PAGE_PLUS_WRITE = 0x05
     PAGE_PLUS_READ = 0x06
 


### PR DESCRIPTION
This is an initial attempt to support these PSUs.  The implementation started as a port of corsaiRMi, but later a few (important) elements were also incorporated from OpenCorsairLink.

---

Trivia: it was supposed to be a port to a kernel hwmon driver, sometime in the future.  But, after a bit of miscommunication in #36 and renewed interested in #31, I decided to look into this here & now.