### PR TITLE
Add support for single vs. multi rail +12V OCP on Corsair PSUs

### DIFF
--- a/docs/corsair-hxi-rmi.md
+++ b/docs/corsair-hxi-rmi.md
@@ -11,7 +11,9 @@ It is necessary to initialize the device it has been powered on.
 # liquidctl initialize
 ```
 
-The +12V rails normally function in multiple-rail mode.  Single-rail mode can be selected by passing `--single-12v-ocp` to `initialize`.
+The +12V rails normally function in multiple-rail mode, and `initialize` will set the PSU to that mode if necessary.  Single-rail mode can be selected by passing `--single-12v-ocp` to `initialize`.
+
+_Note: changing the +12V OCP mode is at the moment an experimental feature._
 
 ## Monitoring
 

--- a/docs/corsair-hxi-rmi.md
+++ b/docs/corsair-hxi-rmi.md
@@ -11,8 +11,7 @@ It is necessary to initialize the device it has been powered on.
 # liquidctl initialize
 ```
 
-By the default the device will be initialized with multi rail +12V OCP.  If single rail +12V OCP is desired, pass `--single-12v-ocp`.
-
+The +12V rails normally function in multiple-rail mode.  Single-rail mode can be selected by passing `--single-12v-ocp` to `initialize`.
 
 ## Monitoring
 

--- a/docs/corsair-hxi-rmi.md
+++ b/docs/corsair-hxi-rmi.md
@@ -11,6 +11,8 @@ It is necessary to initialize the device it has been powered on.
 # liquidctl initialize
 ```
 
+By the default the device will be initialized with multi rail +12V OCP.  If single rail +12V OCP is desired, pass `--single-12v-ocp`.
+
 
 ## Monitoring
 
@@ -26,6 +28,7 @@ Temperature 2                            40.8  °C
 Fan speed                                   0  rpm
 Input voltage                          230.00  V
 Total power                            110.00  W
++12V OCP mode                      Multi rail
 +12V output voltage                     12.12  V
 +12V output current                      7.75  A
 +12V output power                       92.00  W

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -133,6 +133,9 @@ Override API for USB HIDs: usb, hid or hidraw.
 .B \-\-legacy\-690lc
 Use Asetek 690LC in legacy mode (old Krakens).
 .TP
+.B \-\-single-12v-ocp
+Enable single rail +12V OCP
+.TP
 .B \-\-version
 Display the version number.
 .TP

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -249,8 +249,9 @@ Fan channels: none (feature not supported yet).
 .PP
 Lighting channels: none.
 .PP
-The +12V rails normally function in multiple-rail mode.  Single-rail mode can
-be selected by passing \fB\-\-single\-12v\-ocp\fR to \fBinitialize\fR.
+(Experimental feature) The +12V rails normally function in multiple-rail mode.
+Single-rail mode can be selected by passing \fB\-\-single\-12v\-ocp\fR to
+\fBinitialize\fR.
 .
 .SS NZXT E500, E650, E850
 Fan channels: none (feature not supported yet).

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -134,7 +134,7 @@ Override API for USB HIDs: usb, hid or hidraw.
 Use Asetek 690LC in legacy mode (old Krakens).
 .TP
 .B \-\-single-12v-ocp
-Enable single rail +12V OCP
+Enable single rail +12V OCP.
 .TP
 .B \-\-version
 Display the version number.
@@ -245,6 +245,13 @@ where the allowed values are: \fIslowest\fR, \fIslow\fR, \fInormal\fR,
 .
 .SS Corsair HX750i, HX850i, HX1000i, HX1200i
 .SS Corsair RM650i, RM750i, RM850i, RM1000i
+Fan channels: none (feature not supported yet).
+.PP
+Lighting channels: none.
+.PP
+The +12V rails normally function in multiple-rail mode.  Single-rail mode can
+be selected by passing \fB\-\-single\-12v\-ocp\fR to \fBinitialize\fR.
+.
 .SS NZXT E500, E650, E850
 Fan channels: none (feature not supported yet).
 .PP

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -28,6 +28,7 @@ Animation options (devices/modes can support zero or more):
   --alert-color <color>       Color used by the visual high temperature alert
 
 Other options:
+  --single-12v-ocp            Enable single rail +12V OCP
   -v, --verbose               Output additional information
   -g, --debug                 Show debug information on stderr
   --hid <module>              Override API for USB HIDs: usb, hid or hidraw
@@ -94,6 +95,7 @@ _OPTIONS_TO_FORWARD = [
     '--time-off',
     '--alert-threshold',
     '--alert-color',
+    '--single-12v-ocp',
 ]
 
 # custom number formats for values of select units

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -28,11 +28,11 @@ Animation options (devices/modes can support zero or more):
   --alert-color <color>       Color used by the visual high temperature alert
 
 Other options:
-  --single-12v-ocp            Enable single rail +12V OCP
   -v, --verbose               Output additional information
   -g, --debug                 Show debug information on stderr
   --hid <module>              Override API for USB HIDs: usb, hid or hidraw
   --legacy-690lc              Use Asetek 690LC in legacy mode (old Krakens)
+  --single-12v-ocp            Enable single rail +12V OCP
   --version                   Display the version number
   --help                      Show this message
 

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -106,7 +106,7 @@ class CorsairHidPsuDriver(UsbHidDriver):
         self._write([0xfe, 0x03])  # not well understood
         self._read()
         mode = OCPMode.SINGLE_RAIL if single_12v_ocp else OCPMode.MULTI_RAIL
-        self._exec(WriteBit.WRITE, _CORSAIR_12V_OCP_MODE, mode.value)
+        self._exec(WriteBit.WRITE, _CORSAIR_12V_OCP_MODE, [mode.value])
         self.device.release()
 
     def get_status(self, **kwargs):
@@ -154,7 +154,7 @@ class CorsairHidPsuDriver(UsbHidDriver):
 
     def _get_byte(self, command):
         """Get float value with `command`."""
-        return self._exec(WriteBit.READ, command)[2:3]
+        return self._exec(WriteBit.READ, command)[2]
 
     def _get_float(self, command):
         """Get float value with `command`."""

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -78,7 +78,7 @@ class OCPMode(Enum):
     MULTI_RAIL = 0x2
 
     def __str__(self):
-        return self.name.capitalize().replace('_', '')
+        return self.name.capitalize().replace('_', ' ')
 
 
 class CorsairHidPsuDriver(UsbHidDriver):

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -15,7 +15,7 @@ Supported features
  - [✓] electrical input monitoring
  - [✓] electrical output monitoring
  - [ ] fan control
- - [ ] 12V multirail configuration
+ - [✓] +12V single or multi rail OCP
 
 
 Port of corsaiRMi: incorporates or uses as reference work by notaz and realies,
@@ -48,6 +48,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import logging
 
 from datetime import timedelta
+from enum import Enum
 
 from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.pmbus import CommandCode as CMD
@@ -62,11 +63,22 @@ _SLAVE_ADDRESS = 0x02
 _CORSAIR_READ_TOTAL_UPTIME = CMD.MFR_SPECIFIC_01
 _CORSAIR_READ_UPTIME = CMD.MFR_SPECIFIC_02
 _CORSAIR_READ_INPUT_POWER = CMD.MFR_SPECIFIC_30
+_CORSAIR_12V_OCP_MODE = CMD.MFR_SPECIFIC_08
 
 _RAIL_12V = 0x0
 _RAIL_5V = 0x1
 _RAIL_3P3V = 0x2
 _RAIL_NAMES = {_RAIL_12V : '+12V', _RAIL_5V : '+5V', _RAIL_3P3V : '+3.3V'}
+
+
+class OCPMode(Enum):
+    """Overcurrent protection mode."""
+
+    SINGLE_RAIL = 0x1
+    MULTI_RAIL = 0x2
+
+    def __str__(self):
+        return self.name.capitalize().replace('_', '')
 
 
 class CorsairHidPsuDriver(UsbHidDriver):
@@ -83,7 +95,7 @@ class CorsairHidPsuDriver(UsbHidDriver):
         (0x1b1c, 0x1c0d, None, 'Corsair RM1000i (experimental)', {}),
     ]
 
-    def initialize(self, **kwargs):
+    def initialize(self, single_12v_ocp=False, **kwargs):
         """Initialize the device.
 
         Necessary to receive non-zero value responses from the device.
@@ -93,6 +105,8 @@ class CorsairHidPsuDriver(UsbHidDriver):
         """
         self._write([0xfe, 0x03])  # not well understood
         self._read()
+        mode = OCPMode.SINGLE_RAIL if single_12v_ocp else OCPMode.MULTI_RAIL
+        self._exec(WriteBit.WRITE, _CORSAIR_12V_OCP_MODE, mode.value)
         self.device.release()
 
     def get_status(self, **kwargs):
@@ -110,7 +124,8 @@ class CorsairHidPsuDriver(UsbHidDriver):
             ('Temperature 2', self._get_float(CMD.READ_TEMPERATURE_2), '°C'),
             ('Fan speed', self._get_float(CMD.READ_FAN_SPEED_1), 'rpm'),
             ('Input voltage', self._get_float(CMD.READ_VIN), 'V'),
-            ('Total power', self._get_float(_CORSAIR_READ_INPUT_POWER), 'W')
+            ('Total power', self._get_float(_CORSAIR_READ_INPUT_POWER), 'W'),
+            ('+12V OCP mode', OCPMode(self._get_byte(_CORSAIR_12V_OCP_MODE)), ''),
         ]
         for rail in [_RAIL_12V, _RAIL_5V, _RAIL_3P3V]:
             name = _RAIL_NAMES[rail]
@@ -136,6 +151,10 @@ class CorsairHidPsuDriver(UsbHidDriver):
     def _exec(self, writebit, command, data=None):
         self._write([_SLAVE_ADDRESS | WriteBit(writebit), CMD(command)] + (data or []))
         return self._read()
+
+    def _get_byte(self, command):
+        """Get float value with `command`."""
+        return self._exec(WriteBit.READ, command)[2:3]
 
     def _get_float(self, command):
         """Get float value with `command`."""

--- a/liquidctl/pmbus.py
+++ b/liquidctl/pmbus.py
@@ -74,6 +74,7 @@ class CommandCode(IntEnum):
 
     MFR_SPECIFIC_01 = 0xd1
     MFR_SPECIFIC_02 = 0xd2
+    MFR_SPECIFIC_08 = 0xd8
     MFR_SPECIFIC_12 = 0xdc
     MFR_SPECIFIC_30 = 0xee
     MFR_SPECIFIC_44 = 0xfc


### PR DESCRIPTION
Related: #45 ("Improve support for Corsair HXi/RMi PSUs")

Adds a new option for initialize:

```
# liquidctl initialize
# liquidctl initialize --single-12v-ocp
```

Additionally, status should now also display the OCP mode:

```
# liquidctl status
Device 0, Corsair RM650i (experimental)
...
+12V OCP mode                      Multi rail
+12V output voltage                     12.12  V
+12V output current                      7.75  A
...
```

---

**Please test this feature and report back.**

Even though a realistic OCP test is not trivial for most users, confirming that we can correctly read the OCP mode should be enough (because of how the protocol works):

 1. Initialize the device and take note of the OCP mode reported by status
 2. Pass the device through to a VM running Windows
 3. In CorsairLink or iCue toggle the OCP mode
 4. Give back control of the device to the host, **don't run initialize again** and check that status correctly reports the change
 5. Go back to 2, but this time select the other OCP mode

---

Thank you @olielvewen for the comprehensive USB traffic captures.