### PR TITLE
Implement fan control for Corsair HXi/RMi power supplies

### DIFF
--- a/docs/corsair-hxi-rmi.md
+++ b/docs/corsair-hxi-rmi.md
@@ -4,16 +4,16 @@
 
 ## Initialization
 
-It is necessary to initialize the device it has been powered on.
+It is necessary to initialize the device once it has been powered on.
 
 
 ```
 # liquidctl initialize
 ```
 
-The +12V rails normally function in multiple-rail mode, and `initialize` will set the PSU to that mode if necessary.  Single-rail mode can be selected by passing `--single-12v-ocp` to `initialize`.
+The +12V rails normally function in multiple-rail mode, and `initialize` will by default reset the PSU to that mode; single-rail mode can be selected by passing `--single-12v-ocp` to `initialize`.
 
-_Note: changing the +12V OCP mode is at the moment an experimental feature._
+_Note: changing the +12V OCP mode is currently an experimental feature._
 
 ## Monitoring
 
@@ -44,12 +44,10 @@ Total power                            110.00  W
 
 ## Fan speed
 
-The fan speed is normally controlled automatically by the PSU.
-
-It is possible to override this and set it to a fixed duty value using the `fan` channel.
+The fan speed is normally controlled automatically by the PSU.  It is possible to override this and set the fan to a fixed duty value using the `fan` channel.
 
 ```
 # liquidctl set fan speed 90
 ```
 
-This changes the fan mode to software control.  To revert back to hardware control, re-`initialize` the device.
+This changes the fan control mode to software control and sets the minimum allowed duty value to 30%.  To revert back to hardware control, re-`initialize` the device.

--- a/docs/corsair-hxi-rmi.md
+++ b/docs/corsair-hxi-rmi.md
@@ -26,6 +26,7 @@ Current uptime                        3:43:54
 Total uptime                 9 days, 11:43:54
 Temperature 1                            50.0  °C
 Temperature 2                            40.8  °C
+Fan control mode                     Hardware
 Fan speed                                   0  rpm
 Input voltage                          230.00  V
 Total power                            110.00  W
@@ -40,3 +41,15 @@ Total power                            110.00  W
 +3.3V output current                     1.56  A
 +3.3V output power                       5.00  W
 ```
+
+## Fan speed
+
+The fan speed is normally controlled automatically by the PSU.
+
+It is possible to override this and set it to a fixed duty value using the `fan` channel.
+
+```
+# liquidctl set fan speed 90
+```
+
+This changes the fan mode to software control.  To revert back to hardware control, re-`initialize` the device.

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -254,7 +254,8 @@ back to hardware control, run \fBinitialize\fR again.
 .PP
 (Experimental feature) The +12V rails normally function in multiple-rail mode.
 Single-rail mode can be selected by passing \fB\-\-single\-12v\-ocp\fR to
-\fBinitialize\fR.
+\fBinitialize\fR.  To revert back to multitple-rail mode, run \fBinitialize\fR
+again without that flag.
 .
 .SS NZXT E500, E650, E850
 Fan channels: none (feature not supported yet).

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -245,9 +245,12 @@ where the allowed values are: \fIslowest\fR, \fIslow\fR, \fInormal\fR,
 .
 .SS Corsair HX750i, HX850i, HX1000i, HX1200i
 .SS Corsair RM650i, RM750i, RM850i, RM1000i
-Fan channels: none (feature not supported yet).
+Fan channels: \fIfan\fR.
 .PP
 Lighting channels: none.
+.PP
+Setting a fixed fan speed changes the fan mode to software control.  To revert
+back to hardware control, run \fBinitialize\fR again.
 .PP
 (Experimental feature) The +12V rails normally function in multiple-rail mode.
 Single-rail mode can be selected by passing \fB\-\-single\-12v\-ocp\fR to

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -11,11 +11,11 @@ Supported devices
 Supported features
 ------------------
 
- - [✓] general device monitoring
- - [✓] electrical input monitoring
- - [✓] electrical output monitoring
- - [ ] fan control
- - [✓] +12V single or multi rail OCP
+ - general device monitoring
+ - electrical input monitoring
+ - electrical output monitoring
+ - fan control
+ - +12V single or multi rail OCP
 
 
 Port of corsaiRMi: incorporates or uses as reference work by notaz and realies,

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -162,7 +162,7 @@ class CorsairHidPsuDriver(UsbHidDriver):
         LOGGER.info('ensuring fan control is in software mode')
         self._set_fan_control_mode(FanControlMode.SOFTWARE)
         LOGGER.info('setting fan PWM duty to %i%%', duty)
-        self._exec(WriteBit.WRITE, CMD.FAN_COMMAND_1, list(float_to_linear11(duty)))
+        self._exec(WriteBit.WRITE, CMD.FAN_COMMAND_1, [duty])
         self.device.release()
 
     def _write(self, data):

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -52,7 +52,7 @@ from enum import Enum
 
 from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.pmbus import CommandCode as CMD
-from liquidctl.pmbus import WriteBit, linear_to_float
+from liquidctl.pmbus import WriteBit, linear_to_float, float_to_linear11
 
 
 LOGGER = logging.getLogger(__name__)
@@ -64,11 +64,13 @@ _CORSAIR_READ_TOTAL_UPTIME = CMD.MFR_SPECIFIC_01
 _CORSAIR_READ_UPTIME = CMD.MFR_SPECIFIC_02
 _CORSAIR_READ_INPUT_POWER = CMD.MFR_SPECIFIC_30
 _CORSAIR_12V_OCP_MODE = CMD.MFR_SPECIFIC_08
+_CORSAIR_FAN_CONTROL_MODE = CMD.MFR_SPECIFIC_F0
 
 _RAIL_12V = 0x0
 _RAIL_5V = 0x1
 _RAIL_3P3V = 0x2
 _RAIL_NAMES = {_RAIL_12V : '+12V', _RAIL_5V : '+5V', _RAIL_3P3V : '+3.3V'}
+_MIN_FAN_DUTY = 0
 
 
 class OCPMode(Enum):
@@ -79,6 +81,15 @@ class OCPMode(Enum):
 
     def __str__(self):
         return self.name.capitalize().replace('_', ' ')
+
+class FanControlMode(Enum):
+    """Fan control mode."""
+
+    HARDWARE = 0x0
+    SOFTWARE = 0x1
+
+    def __str__(self):
+        return self.name.capitalize()
 
 
 class CorsairHidPsuDriver(UsbHidDriver):
@@ -110,6 +121,9 @@ class CorsairHidPsuDriver(UsbHidDriver):
             # TODO replace log level with info once this has been confimed to work
             LOGGER.warning('(experimental feature) changing +12V OCP mode to %s', mode)
             self._exec(WriteBit.WRITE, _CORSAIR_12V_OCP_MODE, [mode.value])
+        if self._get_fan_control_mode() != FanControlMode.HARDWARE:
+            LOGGER.info('resetting fan control to hardware mode')
+            self._set_fan_control_mode(FanControlMode.HARDWARE)
         self.device.release()
 
     def get_status(self, **kwargs):
@@ -125,6 +139,7 @@ class CorsairHidPsuDriver(UsbHidDriver):
             ('Total uptime', self._get_timedelta(_CORSAIR_READ_TOTAL_UPTIME), ''),
             ('Temperature 1', self._get_float(CMD.READ_TEMPERATURE_1), '°C'),
             ('Temperature 2', self._get_float(CMD.READ_TEMPERATURE_2), '°C'),
+            ('Fan control mode', self._get_fan_control_mode(), ''),
             ('Fan speed', self._get_float(CMD.READ_FAN_SPEED_1), 'rpm'),
             ('Input voltage', self._get_float(CMD.READ_VIN), 'V'),
             ('Total power', self._get_float(_CORSAIR_READ_INPUT_POWER), 'W'),
@@ -140,6 +155,15 @@ class CorsairHidPsuDriver(UsbHidDriver):
         self.device.release()
         LOGGER.warning('reading the +12V OCP mode is an experimental feature')
         return status
+
+    def set_fixed_speed(self, channel, duty, **kwargs):
+        """Set channel to a fixed speed duty."""
+        duty = max(_MIN_FAN_DUTY, min(duty, 100))
+        LOGGER.info('ensuring fan control is in software mode')
+        self._set_fan_control_mode(FanControlMode.SOFTWARE)
+        LOGGER.info('setting fan PWM duty to %i%%', duty)
+        self._exec(WriteBit.WRITE, CMD.FAN_COMMAND_1, float_to_linear11(duty))
+        self.device.release()
 
     def _write(self, data):
         padding = [0x0]*(_WRITE_LENGTH - len(data))
@@ -159,6 +183,14 @@ class CorsairHidPsuDriver(UsbHidDriver):
     def _get_12v_ocp_mode(self):
         """Get +12V single/multi-rail OCP mode."""
         return OCPMode(self._exec(WriteBit.READ, _CORSAIR_12V_OCP_MODE)[2])
+
+    def _get_fan_control_mode(self):
+        """Get hardware/software fan control mode."""
+        return FanControlMode(self._exec(WriteBit.READ, _CORSAIR_FAN_CONTROL_MODE)[2])
+
+    def _set_fan_control_mode(self, mode):
+        """Set hardware/software fan control mode."""
+        return self._exec(WriteBit.WRITE, _CORSAIR_FAN_CONTROL_MODE, [mode])
 
     def _get_float(self, command):
         """Get float value with `command`."""

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -190,7 +190,7 @@ class CorsairHidPsuDriver(UsbHidDriver):
 
     def _set_fan_control_mode(self, mode):
         """Set hardware/software fan control mode."""
-        return self._exec(WriteBit.WRITE, _CORSAIR_FAN_CONTROL_MODE, [mode])
+        return self._exec(WriteBit.WRITE, _CORSAIR_FAN_CONTROL_MODE, [mode.value])
 
     def _get_float(self, command):
         """Get float value with `command`."""

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -162,7 +162,7 @@ class CorsairHidPsuDriver(UsbHidDriver):
         LOGGER.info('ensuring fan control is in software mode')
         self._set_fan_control_mode(FanControlMode.SOFTWARE)
         LOGGER.info('setting fan PWM duty to %i%%', duty)
-        self._exec(WriteBit.WRITE, CMD.FAN_COMMAND_1, float_to_linear11(duty))
+        self._exec(WriteBit.WRITE, CMD.FAN_COMMAND_1, list(float_to_linear11(duty)))
         self.device.release()
 
     def _write(self, data):

--- a/liquidctl/pmbus.py
+++ b/liquidctl/pmbus.py
@@ -139,11 +139,15 @@ def float_to_linear11(float):
 
     >>> float_to_linear11(3.3).hex()
     '4dc3'
+    >>> float_to_linear11(0.0).hex()
+    '0000'
     >>> linear_to_float(float_to_linear11(2812))
     2812
     >>> linear_to_float(float_to_linear11(-2812))
     -2812
     """
+    if float == 0:
+        return b'\x00\x00'
     max_y = 1023
     n = math.ceil(math.log(math.fabs(float)/max_y, 2))
     y = round(float * 2**(-n))


### PR DESCRIPTION
Related: #45 ("Improve support for Corsair HXi/RMi PSUs")

Adds an implementation for `set_fixed_speed`, allowing fan control through the CLI:

```
# liquidctl set fan speed 35
```

The channel name is not currently enforced, but 'fan' seems like the obvious choice.  The duty cycle is so far only clamped to [0%, 100%].

---

_I still have a few questions..._

Does the code in this branch work?  
What is the minimum duty value for which the unit reacts?

```
# liquidctl initialize

# liquidctl status | grep 'Fan'

# liquidctl set fan speed 100
# liquidctl status | grep 'Fan'

# liquidctl set fan speed 0
# liquidctl status | grep 'Fan'

# liquidctl set fan speed 50
# liquidctl status | grep 'Fan'
...

[suggestion: do a binary search]
```

What happens to the fan speed when the unit doesn't receive constant updates?  Does it permanently stays the same (e.g. if left on 100% for a couple of minutes)?   Or does it revert back to some default behavior?

Presumably the unit must be able to not kill itself if iCue/CorsairLink has crashed.  One possible way to implement that would be for it to honor the specified duty as long as it is above some predefined minimum curve (based on temperature, load, or both).  Can we somehow observe this fallback behavior (e.g. by setting the fan speed to its minimum allowed value and ramping the power draw/temperature)?

Pinging @olielvewen for testing...

---

Missing:

 - [ ] clamping of duty to its minimum useful value
 - [ ] safety considerations