### PR TITLE
Change the device discovery strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ _Man page and support for power supplies (Corsair RXi/HXi and NZXT E) and Smart 
  - **Add experimental support for NZXT E500, E650 and E850 power supplies**
  - **Add experimental support for the NZXT Smart Device V2**
  - Add liquidctl(8) man page
- - Add --single-12v-ocp option
+ - Add `--single-12v-ocp` option
+ - Add `--pick <result>` option
+### Changed
+ - Improve the output of the `list` and `status` commands
+ - Reduce the number of libusb and hidapi calls during device discovery
 
 ## [1.2.0] – 2019-09-27
 _Support for Asetek "5-th gen." 690LC coolers and improvements for HIDs and Mac OS_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,11 @@ _Support for Asetek "5-th gen." 690LC coolers and improvements for HIDs and Mac 
 
 ## [1.2.0rc4] – 2019-09-18
 ### Added
- - Add support for adding git commit and tree cleanliness information to --version
- - Add support for adding distribution name and package information to --version
+ - Add support for adding git commit and tree cleanliness information to `--version`
+ - Add support for adding distribution name and package information to `--version`
 ### Changed
  - [Corsair Asetek 690LC] Enable modern features for all Corsair coolers
- - Include version information in --debug
+ - Include version information in `--debug`
  - Make docs and code consistent on which devices are only experimentally supported
  - Revert "Mark Kraken X31, X41, X51 and X61 as no longer experimental"
  - Improve the documentation
@@ -51,16 +51,16 @@ _Support for Asetek "5-th gen." 690LC coolers and improvements for HIDs and Mac 
 ## [1.2.0rc2] – 2019-09-12
 ### Added
  - Support the EVGA CLC 360
- - Add --alert-threshold and --alert-color
+ - Add `--alert-threshold` and `--alert-color`
 ### Changed
  - Mark Kraken X31, X41, X51 and X61 as no longer experimental
  - Improve supported devices list and links to documentation
- - Don't enable PyUSB tracing automatically with --debug
+ - Don't enable PyUSB tracing automatically with `--debug`
  - [Legacy Asetek 690LC] Cache values read from or stored on the filesystem
  - [Legacy Asetek 690LC] Prefer to save driver data in /run when OS is Linux
 ### Fixes
  - Force bundling of 'hid' module in Windows executable
- - [Legacy Asetek 690LC] Change default fading --time-per-color (see #29)
+ - [Legacy Asetek 690LC] Change default fading `--time-per-color` (see #29)
 
 ## [1.2.0rc1] – 2019-04-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ _Man page and support for power supplies (Corsair RXi/HXi and NZXT E) and Smart 
  - Add `--single-12v-ocp` option
  - Add `--pick <result>` option
 ### Changed
- - Improve the output of the `list` and `status` commands
  - Reduce the number of libusb and hidapi calls during device discovery
+ - Improve the visual hierarchy of the output `list` and `status`
+ - Allow `list --verbose` to run without root privileges (Linux) or special drivers (Windows)
 
 ## [1.2.0] – 2019-09-27
 _Support for Asetek "5-th gen." 690LC coolers and improvements for HIDs and Mac OS_

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ The complete list of commands and options can be seen with `liquidctl --help`, b
 # liquidctl list
 ```
 
-In case more than one supported device is found, `--vendor`, `--product`, `--release`, `--serial`, `--bus`, `--address` and `--usb-port` can be used to select a particular product (see `liquidctl --help`).
+In case more than one supported device is found, `--vendor`, `--product`, `--release`, `--serial`, `--bus`, `--address` and `--usb-port` can be used to select a particular product (see `liquidctl --help`).  If a filter produces multiple results, `--pick` can be used to further select one among them.
 
-The numbers shown by `list` can also be used for device selection with `--device <no>`.  However, these numbers are not guaranteed to remain stable and will vary with hardware changes, liquidctl updates or simply normal enumeration order variance.
+The device IDs shown by `list` with no filters can also be used for device selection with `--device <id>`.  However, these numbers are not guaranteed to remain stable and will vary with hardware changes, liquidctl updates or simply normal enumeration order variance.
 
 Devices will usually need to be initialized before they can be used, though each device has its own requirements and limitations.  This and other information specific to a particular device will appear on the documentation linked in the [supported devices](#supported-devices) section.
 

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -49,11 +49,11 @@ monitoring devices not yet supported at the kernel level.  Because
 generally required, though this can be avoided with appropriate udev rules.
 .PP
 \fBliquidctl list\fR outputs all compatible devices found on the system.  In
-case more than one device is found, the displayed device number can be used to
+case more than one device is found, the device ID can be used to
 select it in later invocations.  Passing \fI\-\-verbose\fR enables the display
 of additional identifiers and addresses that can also be used to select
 specific devices.  These are preferred for non-interactive invocations as they,
-unlike device numbers, are more stable across reboots and software or hardware
+unlike device IDs, are more stable across reboots and software or hardware
 updates.
 .PP
 \fBliquidctl initialize\fR should be called for every device after a reboot,
@@ -98,8 +98,11 @@ Filter devices by address in bus.
 .BI \-\-usb\-port= port
 Filter devices by USB port in bus.
 .TP
-.BI \-d\  number\fR,\ \fP \-\-device= number
-Select device by listing number.
+.BI \-\-pick= number
+Pick among many results for a given filter.
+.TP
+.BI \-d\  id\fR,\ \fP \-\-device= id
+Select device by listing ID.
 .
 .SS Animation options
 Some devices and animation modes support additional options.

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -18,7 +18,8 @@ Device selection options (see: list -v):
   --bus <bus>                 Filter devices by bus
   --address <address>         Filter devices by address in bus
   --usb-port <port>           Filter devices by USB port in bus
-  -d, --device <number>       Select device by listing number
+  --pick <number>             Pick among many results for a given filter
+  -d, --device <id>           Select device by listing id
 
 Animation options (devices/modes can support zero or more):
   --speed <value>             Abstract animation speed (device/mode specific)
@@ -90,6 +91,7 @@ _PARSE_ARG = {
     '--bus': str,
     '--address': str,
     '--usb-port': lambda x: tuple(map(int, x.split('.'))),
+    '--pick': int,
     '--device': int,
 
     '--speed': str,
@@ -114,6 +116,7 @@ _FILTER_OPTIONS = [
     'bus',
     'address',
     'usb-port',
+    'pick',
     'device'
 ]
 
@@ -132,9 +135,9 @@ LOGGER = logging.getLogger(__name__)
 def _list_devices(devices, verbose=False, filtred=False, **opts):
     for i, dev in enumerate(devices):
         if not filtred:
-            print('Device {}: {}'.format(i, dev.description))
+            print('Device ID {}: {}'.format(i, dev.description))
         else:
-            print('{}'.format(dev.description))
+            print('Result #{}: {}'.format(i + 1, dev.description))
         if not verbose:
             continue
         print('  Vendor ID: {:#06x}'.format(dev.vendor_id))
@@ -245,12 +248,12 @@ def main():
 
     opts = _make_opts(args)
 
-    if 'device' in opts:
+    if not 'device' in opts:
+        selected = list(find_liquidctl_devices(**opts))
+    else:
         no_filters = {opt: val for opt, val in opts.items() if opt not in _FILTER_OPTIONS}
         compat = list(find_liquidctl_devices(**no_filters))
         selected = [compat[opts['device']]]
-    else:
-        selected = list(find_liquidctl_devices(**opts))
 
     if args['list']:
         filtred = sum(1 for opt in opts if opt in _FILTER_OPTIONS) > 0

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -155,7 +155,7 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
             msg = 'could not read the serial number'
             if sys.platform.startswith('linux') and os.geteuid:
                 msg += ' (requires root privileges)'
-            elif 'win' in sys.platform and 'Hid' not in dev.device.__name__:
+            elif 'win' in sys.platform and 'Hid' not in type(dev.device).__name__:
                 msg += ' (device possibly requires a kernel driver)'
             if debug:
                 LOGGER.exception(msg.capitalize())

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -155,7 +155,7 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
             msg = 'could not read the serial number'
             if sys.platform.startswith('linux') and os.geteuid:
                 msg += ' (requires root privileges)'
-            elif 'win' in sys.platform and 'Hid' not in type(dev.device).__name__:
+            elif sys.platform in ['win32', 'cygwin'] and 'Hid' not in type(dev.device).__name__:
                 msg += ' (device possibly requires a kernel driver)'
             if debug:
                 LOGGER.exception(msg.capitalize())

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -32,12 +32,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from liquidctl.driver.base import BaseBus, find_all_subclasses
 import liquidctl.driver.asetek
 import liquidctl.driver.corsair_hid_psu
 import liquidctl.driver.kraken_two
 import liquidctl.driver.nzxt_smart_device
 import liquidctl.driver.seasonic
+
+from liquidctl.driver.base import BaseBus, find_all_subclasses
 
 
 def find_liquidctl_devices(device=None, **kwargs):
@@ -64,6 +65,7 @@ def find_liquidctl_devices(device=None, **kwargs):
                 num += 1
             else:
                 yield dev
+
 
 __all__ = [
     'find_liquidctl_devices',

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -32,17 +32,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-__all__ = [
-    'asetek',
-    'corsair_hid_psu',
-    'kraken_two',
-    'nzxt_smart_device',
-    'seasonic',
-
-    'find_liquidctl_devices',
-]
-
-from .base import BaseBus, find_all_subclasses
+from liquidctl.driver.base import BaseBus, find_all_subclasses
+import liquidctl.driver.asetek
+import liquidctl.driver.corsair_hid_psu
+import liquidctl.driver.kraken_two
+import liquidctl.driver.nzxt_smart_device
+import liquidctl.driver.seasonic
 
 
 def find_liquidctl_devices(device=None, **kwargs):
@@ -69,3 +64,7 @@ def find_liquidctl_devices(device=None, **kwargs):
                 num += 1
             else:
                 yield dev
+
+__all__ = [
+    'find_liquidctl_devices',
+]

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -34,15 +34,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = [
     'asetek',
-    'base',
     'corsair_hid_psu',
     'kraken_two',
     'nzxt_smart_device',
     'seasonic',
-    'usb',
 
     'find_liquidctl_devices',
 ]
+
+from .base import BaseBus, find_all_subclasses
 
 
 def find_liquidctl_devices(device=None, **kwargs):
@@ -58,7 +58,7 @@ def find_liquidctl_devices(device=None, **kwargs):
     If `device` is passed, only the driver instance for the `(device + 1)`-th
     matched device will be yielded.
     """
-    buses = sorted(base.find_all_subclasses(base.BaseBus), key=lambda x: x.__name__)
+    buses = sorted(find_all_subclasses(BaseBus), key=lambda x: x.__name__)
     num = 0
     for bus_cls in buses:
         for dev in  bus_cls().find_devices(**kwargs):

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -51,7 +51,7 @@ def find_liquidctl_devices(pick=None, **kwargs):
     `**kwargs`.  A driver instance will be yielded for each compatible device
     that matches the supplied filter conditions.
 
-    If `pick` is passed, only the driver instance for the `pick`-th
+    If `pick` is passed, only the driver instance for the `(pick + 1)`-th
     matched device will be yielded.
     """
     buses = sorted(find_all_subclasses(BaseBus), key=lambda x: x.__name__)
@@ -59,10 +59,10 @@ def find_liquidctl_devices(pick=None, **kwargs):
     for bus_cls in buses:
         for dev in  bus_cls().find_devices(**kwargs):
             if not pick is None:
-                num += 1
                 if num == pick:
                     yield dev
                     return
+                num += 1
             else:
                 yield dev
 

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -41,7 +41,7 @@ import liquidctl.driver.seasonic
 from liquidctl.driver.base import BaseBus, find_all_subclasses
 
 
-def find_liquidctl_devices(device=None, **kwargs):
+def find_liquidctl_devices(pick=None, **kwargs):
     """Find devices and instantiate corresponding liquidctl drivers.
 
     Probes all buses and drivers that have been loaded by the time of the call
@@ -51,18 +51,18 @@ def find_liquidctl_devices(device=None, **kwargs):
     `**kwargs`.  A driver instance will be yielded for each compatible device
     that matches the supplied filter conditions.
 
-    If `device` is passed, only the driver instance for the `(device + 1)`-th
+    If `pick` is passed, only the driver instance for the `pick`-th
     matched device will be yielded.
     """
     buses = sorted(find_all_subclasses(BaseBus), key=lambda x: x.__name__)
     num = 0
     for bus_cls in buses:
         for dev in  bus_cls().find_devices(**kwargs):
-            if not device is None:
-                if num == device:
+            if not pick is None:
+                num += 1
+                if num == pick:
                     yield dev
                     return
-                num += 1
             else:
                 yield dev
 

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -1,0 +1,71 @@
+"""Drivers and buses package for liquidctl.
+
+The typical use case of generic scripts and interfaces – including the
+liquidctl CLI – is to instantiate drivers for all known devices found on the
+system.
+
+    from liquidctl.driver import *
+    for dev in find_liquidctl_devices():
+        print(dev.description)
+
+Is also possible to find devices compatible with a specific driver.
+
+    from liquidctl.driver.kraken_two import KrakenTwoDriver
+    for dev in KrakenTwoDriver.find_supported_devices():
+        print(dev.description)
+
+__init__.py file of the drivers and buses package for liquidctl
+Copyright (C) 2019  Jonas Malaco
+Copyright (C) 2019  each contribution's author
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+__all__ = [
+    'asetek',
+    'base',
+    'corsair_hid_psu',
+    'kraken_two',
+    'nzxt_smart_device',
+    'seasonic',
+    'usb',
+
+    'find_liquidctl_devices',
+]
+
+
+def find_liquidctl_devices(device=None, **kwargs):
+    """Find devices and instantiate corresponding liquidctl drivers.
+
+    Probes all buses and drivers that have been loaded by the time of the call
+    and yields driver instances.
+
+    Filter conditions can be passed through to the buses and drivers via
+    `**kwargs`.  A driver instance will be yielded for each compatible device
+    that matches the supplied filter conditions.
+
+    If `device` is passed, only the driver instance for the `(device + 1)`-th
+    matched device will be yielded.
+    """
+    buses = sorted(base.find_all_subclasses(base.BaseBus), key=lambda x: x.__name__)
+    num = 0
+    for bus_cls in buses:
+        for dev in  bus_cls().find_devices(**kwargs):
+            if not device is None:
+                if num == device:
+                    yield dev
+                    return
+                num += 1
+            else:
+                yield dev

--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -49,7 +49,7 @@ import sys
 import appdirs
 import usb
 
-from liquidctl.driver.usb import UsbDeviceDriver
+from liquidctl.driver.usb import UsbDriver
 from liquidctl.util import color_from_str
 
 
@@ -106,7 +106,7 @@ def _clamp(val, lo, hi, none=None, desc='value'):
         return val
 
 
-class CommonAsetekDriver(UsbDeviceDriver):
+class CommonAsetekDriver(UsbDriver):
     """Common fuctions of fifth generation Asetek devices."""
 
     def _configure_flow_control(self, clear_to_send):
@@ -206,11 +206,10 @@ class AsetekDriver(CommonAsetekDriver):
     ]
 
     @classmethod
-    def find_supported_devices(cls, legacy_690lc=False, **kwargs):
-        """Find and bind to compatible devices."""
+    def probe(cls, handle, legacy_690lc=False, **kwargs):
         if legacy_690lc:
-            return []
-        return super().find_supported_devices(**kwargs)
+            return None
+        return super().probe(handle, **kwargs)
 
     def get_status(self, **kwargs):
         """Get a status report.
@@ -315,11 +314,10 @@ class LegacyAsetekDriver(CommonAsetekDriver):
     ]
 
     @classmethod
-    def find_supported_devices(cls, legacy_690lc=False, **kwargs):
-        """Find and bind to compatible devices."""
+    def probe(cls, handle, legacy_690lc=False, **kwargs):
         if not legacy_690lc:
-            return []
-        return super().find_supported_devices(**kwargs)
+            return None
+        return super().probe(handle, **kwargs)
 
     def __init__(self, device, description, **kwargs):
         super().__init__(device, description, **kwargs)
@@ -458,11 +456,10 @@ class CorsairAsetekDriver(AsetekDriver):
     ]
 
     @classmethod
-    def find_supported_devices(cls, legacy_690lc=None, **kwargs):
-        """Find and bind to compatible devices."""
-        # the modern driver overrides find_supported_devices and rigs it to
-        # switch on --legacy-690lc, so we override it again
-        return super().find_supported_devices(legacy_690lc=False, **kwargs)
+    def probe(cls, handle, legacy_690lc=False, **kwargs):
+        # the modern driver overrides probe and rigs it to switch on
+        # --legacy-690lc, so we override it again
+        return super().probe(handle, legacy_690lc=False, **kwargs)
 
     def set_color(self, channel, mode, colors, **kwargs):
         if mode == 'rainbow':

--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -207,8 +207,8 @@ class AsetekDriver(CommonAsetekDriver):
     @classmethod
     def probe(cls, handle, legacy_690lc=False, **kwargs):
         if legacy_690lc:
-            return None
-        return super().probe(handle, **kwargs)
+            return
+        yield from super().probe(handle, **kwargs)
 
     def get_status(self, **kwargs):
         """Get a status report.
@@ -308,8 +308,8 @@ class LegacyAsetekDriver(CommonAsetekDriver):
     @classmethod
     def probe(cls, handle, legacy_690lc=False, **kwargs):
         if not legacy_690lc:
-            return None
-        return super().probe(handle, **kwargs)
+            return
+        yield from super().probe(handle, **kwargs)
 
     def __init__(self, device, description, **kwargs):
         super().__init__(device, description, **kwargs)

--- a/liquidctl/driver/base.py
+++ b/liquidctl/driver/base.py
@@ -138,3 +138,18 @@ class BaseDriver:
         """
         raise NotImplementedError()
 
+
+class BaseBus:
+    """Base bus API."""
+
+    def find_devices(self, **kwargs):
+        return []
+
+
+def find_all_subclasses(cls):
+    """Recursively find loaded subclasses of `cls`.
+
+    Returns a set of subclasses of `cls`.
+    """
+    sub = set(cls.__subclasses__())
+    return sub.union([s for c in cls.__subclasses__() for s in find_all_subclasses(c)])

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -323,6 +323,9 @@ class PyUsbDevice:
     def port(self):
         return self.usbdev.port_numbers
 
+    def __eq__(self, other):
+        return type(self) == type(other) and self.bus == other.bus and self.address == other.address
+
 
 class PyUsbHid(PyUsbDevice):
     """A PyUSB backed HID device.
@@ -431,6 +434,9 @@ class HidapiDevice:
     @property
     def port(self):
         return None
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.bus == other.bus and self.address == other.address
 
 
 class UsbHidBus(BaseBus):

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -443,7 +443,7 @@ class HidapiDevice:
         return type(self) == type(other) and self.bus == other.bus and self.address == other.address
 
 
-class UsbHidBus(BaseBus):
+class GenericHidBus(BaseBus):
 
     def find_devices(self, vendor=None, product=None, hid=None, bus=None,
                      address=None, usb_port=None, **kwargs):
@@ -490,7 +490,7 @@ class UsbHidBus(BaseBus):
                 yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)
 
 
-class UsbBus(BaseBus):
+class PyUsbBus(BaseBus):
     def find_devices(self, vendor=None, product=None, bus=None, address=None,
                      usb_port=None, **kwargs):
         """ Find compatible regular USB devices."""

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -186,7 +186,9 @@ class UsbHidDriver(BaseUsbDriver):
         """Find devices specifically compatible with this driver."""
         devs = []
         for vid, pid, _, _, _ in cls.SUPPORTED_DEVICES:
-            devs += UsbHidBus.find_devices(vendor=vid, product=pid, **kwargs)
+            for dev in GenericHidBus().find_devices(vendor=vid, product=pid, **kwargs):
+                if type(dev) == cls:
+                    devs.append(dev)
         return devs
 
     def __init__(self, device, description, **kwargs):
@@ -209,8 +211,9 @@ class UsbDriver(BaseUsbDriver):
     def find_supported_devices(cls, hid=None, **kwargs):
         """Find devices specifically compatible with this driver."""
         devs = []
-        for vid, pid, _, _, _ in cls.SUPPORTED_DEVICES:
-            devs += UsbBus.find_devices(vendor=vid, product=pid, **kwargs)
+        for dev in PyUsbBus().find_devices(vendor=vid, product=pid, **kwargs):
+            if type(dev) == cls:
+                devs.append(dev)
         return devs
 
     def __init__(self, device, description, **kwargs):

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -120,8 +120,7 @@ class BaseUsbDriver(BaseDriver):
             consargs.update(kwargs)
             dev = cls(handle, description, **consargs)
             LOGGER.debug('instanced driver for %s', description)
-            return dev
-        return None
+            yield dev
 
     def connect(self, **kwargs):
         """Connect to the device."""
@@ -488,9 +487,7 @@ class UsbHidBus(BaseBus):
             LOGGER.debug('probing drivers for device %s:%s', hex(handle.vendor_id),
                          hex(handle.product_id))
             for drv in drivers:
-                dev = drv.probe(handle, vendor=vendor, product=product, **kwargs)
-                if dev:
-                    yield dev
+                yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)
 
 
 class UsbBus(BaseBus):
@@ -510,6 +507,4 @@ class UsbBus(BaseBus):
             LOGGER.debug('probing drivers for device %s:%s', hex(handle.vendor_id),
                          hex(handle.product_id))
             for drv in drivers:
-                dev = drv.probe(handle, vendor=vendor, product=product, **kwargs)
-                if dev:
-                    yield dev
+                yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -47,10 +47,10 @@ The USB drivers are organized into two buses.  The recommended way to
 initialize and bind drivers is through their respective buses, though
 <driver>.find_supported_devices can also be useful in certain scenarios.
 
-UsbHidBus
+GenericHidBus
 └── drivers: all (recursive) subclasses of UsbHidDriver
 
-UsbBus
+PyUsbBus
 └── drivers: all (recursive) subclasses of UsbDriver
 
 The subclass constructor can generally be kept unaware of the implementation

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -426,7 +426,7 @@ class HidapiDevice:
 
     @property
     def address(self):
-        return None
+        return self.hidinfo['path'].decode()
 
     @property
     def port(self):


### PR DESCRIPTION
Since liquidctl v1.0.0 we went from supporting a single USB ID to supporting 23 of them.

Because of this, the previous strategy of enumerating lsusb (and later HIDAPI) devices one ID at a time now causes an absurd number of calls to those APIs.

These changes switch device discovery to a more top down approach, where each API (PyUSB/HIDAPI) is enumerated only once.   The gains in CPU time aren't massive (~20% reduction in some cases), but the code quality has also improved a lot.

Because device discovery, device filtering and device listing are somewhat related, this pull request also includes improvements in those areas.

Additionally, the argument forwarding to drivers has also been reworked, since it's also used by the new top-down approach to pass the necessary filters to each driver's probe function.