### PR TITLE
Add support for the NZXT HUE 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Man page and support for power supplies (Corsair RXi/HXi and NZXT E) and Smart 
  - **Add experimental support for Corsair RM650i, RM750i, RM850i and RM1000i power supplies**
  - **Add experimental support for NZXT E500, E650 and E850 power supplies**
  - **Add experimental support for the NZXT Smart Device V2**
+ - **Add experimental support for the NZXT HUE 2**
  - Add liquidctl(8) man page
  - Add `--single-12v-ocp` option to `initialize` (Corsair HXi/RMi PSUs)
  - Add `--pick <result>` device selection option

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ NZXT Kraken X (X42, X52, X62 or X72)
 | Corsair RM650i, RM750i, RM850i, RM1000i | [documentation](docs/corsair-hxi-rmi.md) | <sup>1</sup> |
 | NZXT E500, E650, E850 | [documentation](docs/seasonic-e-series.md) | <sup>1</sup> |
 | NZXT Grid+ V3 | [documentation](docs/nzxt-smart-device.md) | |
+| NZXT HUE 2 | [documentation](docs/nzxt-smart-device-v2.md#experimental-support-for-the-hue-2) | <sup>1</sup> |
 | NZXT Smart Device | [documentation](docs/nzxt-smart-device.md) | |
 | NZXT Smart Device V2 | [documentation](docs/nzxt-smart-device-v2.md) | <sup>1</sup> |
 

--- a/docs/nzxt-smart-device-v2.md
+++ b/docs/nzxt-smart-device-v2.md
@@ -1,4 +1,4 @@
-# NZXT Smart Device V2
+# NZXT Smart Device V2 and HUE 2
 
 The NZXT Smart Device V2 is a newer model of the original Smart Device fan and LED controller. It ships with NZXT's cases released in mid-2019 including the H510 Elite, H510i, H710i, and H210i.
 
@@ -13,6 +13,11 @@ A microphone is still present onboard for noise level optimization through CAM a
 All configuration is done through USB, and persists as long as the device still gets power, even if the system has gone to Soft Off (S5) state.  The device also reports the state of each fan channel, as well as speed and duty (from 0% to 100%).
 
 Most capabilities available at the hardware level are supported, but other features offered by CAM, like noise level optimization and presets based on CPU/GPU temperatures, have not been implemented.
+
+
+## Experimental support for the HUE 2
+
+This driver also has **experimental** support for the NZXT HUE 2 LED controller, which has four LED channels (but no fan speed channels).
 
 
 ## Initialization
@@ -47,6 +52,8 @@ Noise level                             62  dB
 
 ## Fan speeds
 
+_Only NZXT Smart Device V2_
+
 Fan speeds can only be set to fixed duty values.
 
 ```
@@ -65,13 +72,13 @@ Fan speeds can only be set to fixed duty values.
 
 ## RGB lighting
 
-The device features two lighting channels: `led1` and `led2`.  Color modes can be set independently for each lighting channel, but the specified color mode will then apply to all devices daisy chained on that channel.
+The Smart Device V2 features two lighting channels, while the HUE features four, and they are numbered sequentially: `led1`, `led2`, (only HUE 2: `led3`, `led4`).  Color modes can be set independently for each lighting channel, but the specified color mode will then apply to all devices daisy chained on that channel.
 
 ```
 # liquidctl set led1 color fixed af5a2f
-# liquidctl set led1 color fading 350017 ff2608 --speed slower
-# liquidctl set led2 color pulse ffffff
-# liquidctl set led2 color backwards-marquee-5 2f6017 --speed slowest
+# liquidctl set led2 color fading 350017 ff2608 --speed slower
+# liquidctl set led3 color pulse ffffff
+# liquidctl set led4 color backwards-marquee-5 2f6017 --speed slowest
 ```
 
 Colors are set in hexadecimal RGB, and each animation mode supports different number of colors.  The animation speed can be customized with the `--speed <value>`, and five relative values are accepted by the device: `slowest`, `slower`, `normal`, `faster` and `fastest`.

--- a/docs/nzxt-smart-device.md
+++ b/docs/nzxt-smart-device.md
@@ -74,6 +74,8 @@ Fan speeds can only be set to fixed duty values.
 
 ## RGB lighting
 
+_Only NZXT Smart Device (V1)_
+
 For lighting, the user can control up to 40 LEDs, if all four strips or five fans are connected.  They are chained in a single channel: `led`.
 
 ```

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -303,9 +303,12 @@ where the allowed values are: \fIslowest\fR, \fIslow\fR, \fInormal\fR,
 \fIfast\fR, \fIfastest\fR.
 .
 .SS NZXT Smart Device V2
-Fan channels: \fIfan[1\(en3]\fR.
+.SS NZXT HUE 2
+Fan channels (only Smart Device V2): \fIfan[1\(en3]\fR.
 .PP
 Lighting channels: \fIled[1\(en2]\fR.
+.PP
+Additional lighting channels (only HUE 2): \fIled[3\(en4]\fR.
 .TS
 l c
 ----

--- a/liquidctl/driver/nzxt_smart_device.py
+++ b/liquidctl/driver/nzxt_smart_device.py
@@ -303,6 +303,10 @@ class SmartDeviceV2Driver(CommonSmartDeviceDriver):
             'speed_channel_count': 3,
             'color_channel_count': 2
         }),
+        (0x1e71, 0x2001, None, 'NZXT HUE 2 (experimental)', {
+            'speed_channel_count': 0,
+            'color_channel_count': 4
+        }),
     ]
 
     _READ_LENGTH = 64

--- a/liquidctl/driver/nzxt_smart_device.py
+++ b/liquidctl/driver/nzxt_smart_device.py
@@ -1,4 +1,4 @@
-"""liquidctl drivers for NZXT Smart Device V1/V2 and Grid+ V3.
+"""liquidctl drivers for NZXT Smart Device V1/V2, Grid+ V3 and HUE 2.
 
 Smart Device (V1)
 -----------------
@@ -54,6 +54,15 @@ lighting channel supports up to 6 accessories and a total of 40 LEDs.
 
 A microphone is still present onboard for noise level optimization through CAM
 and AI.
+
+HUE 2
+-----
+
+The NZXT HUE 2 is an LED controller from the same generation of the Smart
+Device V2.
+
+The presets and limitations of the four LED channels are the same as in the
+Smart Device V2.
 
 Driver
 ------
@@ -296,7 +305,7 @@ class SmartDeviceDriver(CommonSmartDeviceDriver):
 
 
 class SmartDeviceV2Driver(CommonSmartDeviceDriver):
-    """liquidctl driver for the NZXT Smart Device V2."""
+    """liquidctl driver for the NZXT Smart Device V2 and NZXT HUE 2."""
 
     SUPPORTED_DEVICES = [
         (0x1e71, 0x2006, None, 'NZXT Smart Device V2 (experimental)', {


### PR DESCRIPTION
This modifies the driver originally built for Smart Device V2 to also support the HUE 2.

Related: #61 ("Support for NXZT AER 2 120mm and NZXT HUE 2")