### PR TITLE
Add support for Hue2 ambient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [Unreleased]
 ### Added
  - Enable **experimental support for the NZXT HUE 2** with the Smart Device V2 driver
+ - Enable **experimental support for the NZXT HUE 2 Ambient** with the Smart Device V2 driver
 ### Changed
  - [API] Allow initialize methods to optionally return status tuples
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ NZXT Kraken X (X42, X52, X62 or X72)
 | Corsair RM650i, RM750i, RM850i, RM1000i | [documentation](docs/corsair-hxi-rmi.md) | <sup>1</sup> |
 | NZXT E500, E650, E850 | [documentation](docs/seasonic-e-series.md) | <sup>1</sup> |
 | NZXT Grid+ V3 | [documentation](docs/nzxt-smart-device.md) | |
-| NZXT HUE 2 | [documentation](docs/nzxt-smart-device-v2.md#experimental-support-for-the-hue-2) | <sup>1</sup> |
+| NZXT HUE 2 | [documentation](docs/nzxt-smart-device-v2.md#experimental-support-for-the-hue-2-and-hue-2-ambient-kit) | <sup>1</sup> |
+| NZXT HUE 2 Ambient | [documentation](docs/nzxt-smart-device-v2.md#experimental-support-for-the-hue-2-and-hue-2-ambient-kit) | <sup>1</sup> |
 | NZXT Smart Device | [documentation](docs/nzxt-smart-device.md) | |
 | NZXT Smart Device V2 | [documentation](docs/nzxt-smart-device-v2.md) | <sup>1</sup> |
 

--- a/docs/nzxt-smart-device-v2.md
+++ b/docs/nzxt-smart-device-v2.md
@@ -1,4 +1,4 @@
-# NZXT Smart Device V2 and HUE 2
+# NZXT Smart Device V2, HUE 2 and HUE 2 Ambient
 
 The NZXT Smart Device V2 is a newer model of the original Smart Device fan and LED controller. It ships with NZXT's cases released in mid-2019 including the H510 Elite, H510i, H710i, and H210i.
 
@@ -15,10 +15,9 @@ All configuration is done through USB, and persists as long as the device still 
 Most capabilities available at the hardware level are supported, but other features offered by CAM, like noise level optimization and presets based on CPU/GPU temperatures, have not been implemented.
 
 
-## Experimental support for the HUE 2
+## Experimental support for the HUE 2 and HUE 2 Ambient kit
 
-This driver also has **experimental** support for the NZXT HUE 2 LED controller, which has four LED channels (but no fan speed channels).
-
+This driver also has **experimental** support for the NZXT HUE 2 LED controller, which has four LED channels (but no fan speed channels). HUE 2 Ambient kit is a variant of HUE 2 which has two LED channels and no fan speed channels.
 
 ## Initialization
 
@@ -72,7 +71,7 @@ Fan speeds can only be set to fixed duty values.
 
 ## RGB lighting
 
-The Smart Device V2 features two lighting channels, while the HUE features four, and they are numbered sequentially: `led1`, `led2`, (only HUE 2: `led3`, `led4`).  Color modes can be set independently for each lighting channel, but the specified color mode will then apply to all devices daisy chained on that channel.
+The Smart Device V2 features two lighting channels, while the HUE features four, and they are numbered sequentially: `led1`, `led2`, (only HUE 2: `led3`, `led4`). HUE 2 Ambient has only `led1` and `led2` channels. Color modes can be set independently for each lighting channel, but the specified color mode will then apply to all devices daisy chained on that channel.
 
 ```
 # liquidctl set led1 color fixed af5a2f

--- a/liquidctl/driver/nzxt_smart_device.py
+++ b/liquidctl/driver/nzxt_smart_device.py
@@ -1,4 +1,4 @@
-"""liquidctl drivers for NZXT Smart Device V1/V2, Grid+ V3 and HUE 2.
+"""liquidctl drivers for NZXT Smart Device V1/V2, Grid+ V3, HUE 2 and HUE 2 Ambient.
 
 Smart Device (V1)
 -----------------
@@ -63,6 +63,11 @@ Device V2.
 
 The presets and limitations of the four LED channels are the same as in the
 Smart Device V2.
+
+HUE 2 Ambient
+-----
+
+HUE 2 Ambient is a variant of HUE 2 featuring 2 LED control channels.
 
 Driver
 ------
@@ -305,7 +310,7 @@ class SmartDeviceDriver(CommonSmartDeviceDriver):
 
 
 class SmartDeviceV2Driver(CommonSmartDeviceDriver):
-    """liquidctl driver for the NZXT Smart Device V2 and NZXT HUE 2."""
+    """liquidctl driver for the NZXT Smart Device V2, NZXT HUE 2 and NZXT HUE 2 Ambient."""
 
     SUPPORTED_DEVICES = [
         (0x1e71, 0x2006, None, 'NZXT Smart Device V2 (experimental)', {

--- a/liquidctl/driver/nzxt_smart_device.py
+++ b/liquidctl/driver/nzxt_smart_device.py
@@ -316,6 +316,11 @@ class SmartDeviceV2Driver(CommonSmartDeviceDriver):
             'speed_channel_count': 0,
             'color_channel_count': 4
         }),
+        (0x1e71, 0x2002, None, 'NZXT HUE 2 Ambient (experimental)', {
+            'speed_channel_count': 0,
+            'color_channel_count': 2
+        }),
+
     ]
 
     _MAX_READ_ATTEMPTS = 12


### PR DESCRIPTION
As described in #68 I've added USB device ID to Smart Device V2 driver and updated documentation. 