### PR TITLE
WIP: Add support for Kraken X3 devices from NZXT

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ NZXT Kraken X (X42, X52, X62 or X72)
 | NZXT Kraken X40, X60 | [documentation](docs/asetek-690lc.md) | <sup>_E, L, Z_</sup> |
 | NZXT Kraken X31, X41, X61 | [documentation](docs/asetek-690lc.md) | <sup>_E, L, Z_</sup> |
 | NZXT Kraken X42, X52, X62, X72 | [documentation](docs/nzxt-kraken-x-3rd-generation.md) | |
+| NZXT Kraken X53, X63, X73 | [documentation](docs/nzxt-kraken-x3-devices.md) | <sup>_E_</sup> |
 
 ### Other parts
 

--- a/docs/nzxt-kraken-x3-devices.md
+++ b/docs/nzxt-kraken-x3-devices.md
@@ -36,7 +36,7 @@ First, some important notes...
 
 *You should also consider monitoring your hardware temperatures and setting alerts for overheating components or pump failures.*
 
-With those out of the way, the pump speed can be configured to a fixed duty value or with a profile dependent on the liquid temperature.  Fixed speeds can be set by specifying the desired channel – `fan` or `pump` – and duty.
+With those out of the way, the pump speed can be configured to a fixed duty value or with a profile dependent on the liquid temperature.  Fixed speeds can be set by specifying the channel `pump` and duty.
 
 
 ```

--- a/docs/nzxt-kraken-x3-devices.md
+++ b/docs/nzxt-kraken-x3-devices.md
@@ -1,0 +1,99 @@
+# NZXT X3 devices
+
+## NZXT Kraken X53, X63, X73
+
+The Kraken X53, X63 and X73 compose the fourth generation of liquid coolers by NZXT.  These devices are manufactured by Asetek and house seventh generation Asetek pumps, plus secondary PCBs specially designed by NZXT for enhanced control and lighting.
+
+They incorporate customizable pump speed control, a liquid temperature probe in the block and addressable RGB lighting.  The coolers are powered directly by the power supply unit.
+
+All configuration is done through USB, and persists as long as the device still gets power, even if the system has gone to Soft Off (S5) state.  The cooler also reports pump speed and liquid temperature via USB; pump speed can also be sent to the motherboard (or other device) via the sense pin of a standard fan connector.
+
+All capabilities available at the hardware level are supported, but other features offered by CAM, like presets based on CPU or GPU temperatures, have not been implemented.
+
+
+## Monitoring
+
+The cooler can report the pump speed and liquid temperature.
+
+```
+# liquidctl status
+NZXT Kraken X3 Pump (X53, X63 or X73) (experimental)
+├── Liquid temperature    24.1  °C
+├── Pump speed            1869  rpm
+└── Pump duty               60  %
+```
+
+
+## Pump speeds
+
+First, some important notes...
+
+*You must carefully consider what pump and fan speeds to run.  Heat output, case airflow, radiator size, installed fans and ambient temperature are some of the factors to take into account.  Test your settings under different scenarios, and make sure that they are appropriate, correctly applied and persistent.*
+
+*The X3 devices do not provide a way to control your fan speeds! Please set those fan curves wherever you plugged your fans in (e.g. motherboard).*
+
+*Additionally, the liquid temperature should never reach 60°C, as at that point the pump and tubes might fail or quickly degrade.  You must monitor this during your tests and make any necessary adjustments.  As a safety measure, pump speed will forcibly be programmed to 100% for liquid temperatures of 60°C and above.*
+
+*You should also consider monitoring your hardware temperatures and setting alerts for overheating components or pump failures.*
+
+With those out of the way, the pump speed can be configured to a fixed duty value or with a profile dependent on the liquid temperature.  Fixed speeds can be set by specifying the desired channel – `fan` or `pump` – and duty.
+
+
+```
+# liquidctl set pump speed 90
+```
+
+| Channel | Minimum duty | Maximum duty |
+| --- | --- | --- |
+| pump | 20% | 100% |
+
+For profiles, one or more temperature–duty pairs must be supplied.  Liquidctl will normalize and optimize this profile before pushing it to the Kraken.  Adding `--verbose` will trace the final profile that is being applied.
+
+```
+# liquidctl set pump speed  20 30  30 50  34 80  40 90  50 100
+```
+
+
+## RGB lighting
+
+For lighting, the user can control a total of nine LEDs: one behind the NZXT logo and eight forming the ring that surrounds it.  These are separated into two channels, independently accessed through `logo` and `ring`.
+
+```
+# liquidctl set logo color fixed af5a2f
+# liquidctl set ring color fading 350017 ff2608
+# liquidctl set logo color pulse ffffff
+# liquidctl set ring color backwards-marquee-5 2f6017 --speed slower
+```
+
+Colors can be specified in RGB, HSV or HSL (see [Supported color specification formats](../README.md#supported-color-specification-formats)), and each animation mode supports different number of colors.  The animation speed can be customized with the `--speed <value>`, and five relative values are accepted by the device: `slowest`, `slower`, `normal`, `faster` and `fastest`.
+
+| `ring` | `logo` | Mode | Colors | Speed | Notes |
+| :---: | :---: | --- | --- | :---: | --- |
+| ✓ | ✓ | `off` | None | | 
+| ✓ | ✓ | `fixed` | One | |
+| ✓ | ✓ | `fading` | Between 1 and 8 | ✓ | |
+| ✓ | ✓ | `super-fixed` | Between 1 and 8 | | |
+| ✓ | ✓ | `spectrum-wave` | None | ✓ | |
+| ✓ | ✓ | `backwards-spectrum-wave` | None | ✓ | |
+| ✓ | ✓ | `marquee-<length>` | One | ✓ | 3 ≤ `length` ≤ 6 | 
+| ✓ | ✓ | `backwards-marquee-<length>` | One | ✓ | 3 ≤ `length` ≤ 6 |
+| ✓ | ✓ | `covering-marquee` | Between 1 and 8 | ✓ | |
+| ✓ | ✓ | `covering-backwards-marquee` | Between 1 and 8 | ✓ | |
+| ✓ | ✓ | `alternating-<length>` | Between 1 and 2 | ✓ | |
+| ✓ | ✓ | `moving-alternating-<length>` | Between 1 and 2 | ✓ | 3 ≤ `length` ≤ 6 |
+| ✓ | ✓ | `backwards-moving-alternating-<length>` | Between 1 and 2 | ✓ | 3 ≤ `length` ≤ 6 |
+| ✓ | ✓ | `pulse` | Between 1 and 8 | ✓ | |
+| ✓ | ✓ | `breathing` | Between 1 and 8 | ✓ | |
+| ✓ | ✓ | `super-breathing` | Between 1 and 8 | ✓ | |
+| ✓ | ✓ | `candle` | One | | |
+| ✓ | ✓ | `starry-night` | One | ✓ | |
+| ✓ | ✓ | `rainbow-flow` | None | ✓ | |
+| ✓ | ✓ | `super-rainbow` | None | ✓ | |
+| ✓ | ✓ | `rainbow-pulse` | None | ✓ | |
+| ✓ | ✓ | `backwards-rainbow-flow` | None | ✓ | |
+| ✓ | ✓ | `backwards-super-rainbow` | None | ✓ | |
+| ✓ | ✓ | `backwards-rainbow-pulse` | None | ✓ | |
+| ✓ | ✓ | `loading` | One | | |
+| ✓ | ✓ | `tai-chi` | Between 1 and 2 | ✓ | |
+| ✓ | ✓ | `water-cooler` | Two | ✓ | |
+| ✓ | ✓ | `wings` | One | ✓ | |

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -39,6 +39,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import liquidctl.driver.asetek
 import liquidctl.driver.corsair_hid_psu
 import liquidctl.driver.kraken_two
+import liquidctl.driver.kraken_three_x
 import liquidctl.driver.nzxt_smart_device
 import liquidctl.driver.seasonic
 

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -1,0 +1,54 @@
+"""liquidctl driver for CoolIT Platinum coolers for Corsair.
+
+ Supported devices
+ -----------------
+
+  - [ ] NZXT Kraken X53
+  - [ ] NZXT Kraken X63
+  - [✓] NZXT Kraken X73
+
+ Supported features
+ ------------------
+
+  - [ ] general monitoring
+  - [ ] pump speed control
+  - [ ] lighting control
+
+ ---
+
+ liquidctl driver for Kraken X3 devices from NZXT.
+ Copyright (C) 2020–2020  Jonas Malaco
+ Copyright (C) 2020–2020  each contribution's author
+
+ This file is part of liquidctl.
+
+ liquidctl is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ liquidctl is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ """
+
+import logging
+
+from liquidctl.driver.usb import UsbHidDriver
+
+LOGGER = logging.getLogger(__name__)
+
+_READ_LENGTH = 64
+_WRITE_LENGTH = 64
+
+
+class KrakenThreeX(UsbHidDriver):
+    """liquidctl driver for Kraken X3 devices from NZXT."""
+
+    SUPPORTED_DEVICES = [
+        (0x1e71, 0x2007, None, 'NZXT Kraken X3 Pump (X53, X63 or X73) (experimental)', {})
+    ]

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -239,14 +239,7 @@ class KrakenThreeXDriver(UsbHidDriver):
         if duty < 20 or duty > 100:
             assert False, f'invalid duty value: {duty}. must be between 20 and 100!'
 
-        def parse_pump_speed(msg):
-            if msg[19] == duty:
-                LOGGER.debug(f'pump duty successfully changed to {msg[19]} % [{hex(msg[19])}]')
-            else:
-                assert False, f'pump duty did not update! currently at {msg[19]} % [{hex(msg[19])}]'
-
         self._write([0x72, 0x01, 0x00, 0x00] + [duty] * 40)
-        self._read_until({b'\x75\x02': parse_pump_speed})
         self.device.release()
 
     def _read(self):

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -88,21 +88,21 @@ class KrakenThreeX(UsbHidDriver):
         return [
             ('Liquid temperature', msg[15] + msg[14] / 10, '°C'),
             ('Pump speed', msg[18] << 8 | msg[17], 'rpm'),
-            ('Pump speed', msg[19], '%'),
+            ('Pump duty', msg[19], '%'),
         ]
 
     def set_fixed_speed(self, channel, duty, **kwargs):
         """Set channel to a fixed speed duty."""
         if channel != 'pump':
             assert False, 'kraken X3 devices only support changing pump speeds'
-        if duty < 25 or duty > 100:
-            assert False, f'invalid duty value: {duty}. must be between 25 and 100!'
+        if duty < 20 or duty > 100:
+            assert False, f'invalid duty value: {duty}. must be between 20 and 100!'
 
         def parse_pump_speed(msg):
             if msg[19] == duty:
-                LOGGER.debug(f'pump speed successfully changed to {msg[19]} % [{hex(msg[19])}]')
+                LOGGER.debug(f'pump duty successfully changed to {msg[19]} % [{hex(msg[19])}]')
             else:
-                assert False, f'pump speed did not update! currently at {msg[19]} % [{hex(msg[19])}]'
+                assert False, f'pump duty did not update! currently at {msg[19]} % [{hex(msg[19])}]'
 
         self._write([0x72, 0x01, 0x00, 0x00] + [duty] * 40)
         self._read_until({b'\x75\x02': parse_pump_speed})

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -40,6 +40,7 @@
  """
 
 import logging
+import itertools
 
 from liquidctl.driver.usb import UsbHidDriver
 
@@ -52,6 +53,72 @@ _MAX_READ_ATTEMPTS = 12
 _COLOR_CHANNELS = {
     'ring': 0x02,
     'logo': 0x04,
+}
+_COLOR_MODES = {
+    # (mode, size/variant, speed scale, min colors, max colors)
+    'off':                                  (0x00, 0x00, 0, 0, 0),
+    'fixed':                                (0x00, 0x00, 0, 1, 1),
+    'fading':                               (0x01, 0x00, 1, 1, 8),
+    'spectrum-wave':                        (0x02, 0x00, 2, 0, 0),
+    'backwards-spectrum-wave':              (0x02, 0x00, 2, 0, 0),
+    'marquee-3':                            (0x03, 0x03, 2, 1, 1),
+    'marquee-4':                            (0x03, 0x04, 2, 1, 1),
+    'marquee-5':                            (0x03, 0x05, 2, 1, 1),
+    'marquee-6':                            (0x03, 0x06, 2, 1, 1),
+    'backwards-marquee-3':                  (0x03, 0x03, 2, 1, 1),
+    'backwards-marquee-4':                  (0x03, 0x04, 2, 1, 1),
+    'backwards-marquee-5':                  (0x03, 0x05, 2, 1, 1),
+    'backwards-marquee-6':                  (0x03, 0x06, 2, 1, 1),
+    'covering-marquee':                     (0x04, 0x00, 2, 1, 8),
+    'covering-backwards-marquee':           (0x04, 0x00, 2, 1, 8),
+    'alternating-3':                        (0x05, 0x03, 3, 1, 2),
+    'alternating-4':                        (0x05, 0x04, 3, 1, 2),
+    'alternating-5':                        (0x05, 0x05, 3, 1, 2),
+    'alternating-6':                        (0x05, 0x06, 3, 1, 2),
+    'moving-alternating-3':                 (0x05, 0x03, 4, 1, 2),
+    'moving-alternating-4':                 (0x05, 0x04, 4, 1, 2),
+    'moving-alternating-5':                 (0x05, 0x05, 4, 1, 2),
+    'moving-alternating-6':                 (0x05, 0x06, 4, 1, 2),
+    'backwards-moving-alternating-3':       (0x05, 0x03, 4, 1, 2),
+    'backwards-moving-alternating-4':       (0x05, 0x04, 4, 1, 2),
+    'backwards-moving-alternating-5':       (0x05, 0x05, 4, 1, 2),
+    'backwards-moving-alternating-6':       (0x05, 0x06, 4, 1, 2),
+    'pulse':                                (0x06, 0x00, 5, 1, 8),
+    'breathing':                            (0x07, 0x00, 6, 1, 8),
+    'candle':                               (0x08, 0x00, 0, 1, 1),
+    'starry-night':                         (0x09, 0x00, 5, 1, 1),
+    'rainbow-flow':                         (0x0b, 0x00, 2, 0, 0),
+    'super-rainbow':                        (0x0c, 0x00, 2, 0, 0),
+    'rainbow-pulse':                        (0x0d, 0x00, 2, 0, 0),
+    'backwards-rainbow-flow':               (0x0b, 0x00, 2, 0, 0),
+    'backwards-super-rainbow':              (0x0c, 0x00, 2, 0, 0),
+    'backwards-rainbow-pulse':              (0x0b, 0x00, 2, 0, 0),
+    'loading':                              (0x10, 0x00, 8, 1, 1),
+    'tai-chi':                              (0x0e, 0x00, 7, 1, 2),
+    # 'water-cooler':                         (0x0f, 0x00, 6, 0, 0),
+}
+_STATIC_VALUE = {
+    0x02: 0x08,
+    0x04: 0x01
+}
+_SPEED_VALUE = {
+    # (slowest, slow, normal, fast, fastest)
+    0: ([0x32, 0x00], [0x32, 0x00], [0x32, 0x00], [0x32, 0x00], [0x32, 0x00]),
+    1: ([0x50, 0x00], [0x3c, 0x00], [0x28, 0x00], [0x14, 0x00], [0x0a, 0x00]),
+    2: ([0x5e, 0x01], [0x2c, 0x01], [0xfa, 0x00], [0x96, 0x00], [0x50, 0x00]),
+    3: ([0x40, 0x06], [0x14, 0x05], [0xe8, 0x03], [0x20, 0x03], [0x58, 0x02]),
+    4: ([0x20, 0x03], [0xbc, 0x02], [0xf4, 0x01], [0x90, 0x01], [0x2c, 0x01]),
+    5: ([0x19, 0x00], [0x14, 0x00], [0x0f, 0x00], [0x07, 0x00], [0x04, 0x00]),
+    6: ([0x28, 0x00], [0x1e, 0x00], [0x14, 0x00], [0x0a, 0x00], [0x04, 0x00]),
+    7: ([0x32, 0x00], [0x28, 0x00], [0x1e, 0x00], [0x14, 0x00], [0x0a, 0x00]),
+    8: ([0x14, 0x00], [0x14, 0x00], [0x14, 0x00], [0x14, 0x00], [0x14, 0x00]),
+}
+_ANIMATION_SPEEDS = {
+    'slowest': 0x0,
+    'slower': 0x1,
+    'normal': 0x2,
+    'faster': 0x3,
+    'fastest': 0x4,
 }
 _ACCESSORY_NAMES = {
     0x01: "HUE+ LED Strip",
@@ -66,6 +133,7 @@ _ACCESSORY_NAMES = {
     0x10: "Kraken X3 Pump Ring",
     0x11: "Kraken X3 Pump Logo",
 }
+
 
 class KrakenThreeX(UsbHidDriver):
     """liquidctl driver for Kraken X3 devices from NZXT."""
@@ -128,6 +196,24 @@ class KrakenThreeX(UsbHidDriver):
             ('Pump duty', msg[19], '%'),
         ]
 
+    def set_color(self, channel, mode, colors, speed='normal', **kwargs):
+        """Set the color mode for a specific channel."""
+        cid = _COLOR_CHANNELS[channel]
+        _, _, _, mincolors, maxcolors = _COLOR_MODES[mode]
+        colors = [[g, r, b] for [r, g, b] in colors]
+        if len(colors) < mincolors:
+            raise ValueError('Not enough colors for mode={}, at least {} required'.format(mode, mincolors))
+        elif maxcolors == 0:
+            if colors:
+                LOGGER.warning('too many colors for mode=%s, none needed', mode)
+            colors = [[0, 0, 0]]  # discard the input but ensure at least one step
+        elif len(colors) > maxcolors:
+            LOGGER.warning('too many colors for mode=%s, dropping to %i', mode, maxcolors)
+            colors = colors[:maxcolors]
+        sval = _ANIMATION_SPEEDS[speed]
+        self._write_colors(cid, mode, colors, sval)
+        self.device.release()
+
     def set_fixed_speed(self, channel, duty, **kwargs):
         """Set channel to a fixed speed duty."""
         if channel != 'pump':
@@ -164,6 +250,40 @@ class KrakenThreeX(UsbHidDriver):
         assert False, f'missing messages (attempts={_MAX_READ_ATTEMPTS}, missing={len(parsers)})'
 
     def _write(self, data):
-        padding = [0x0]*(_WRITE_LENGTH - len(data))
+        padding = [0x0] * (_WRITE_LENGTH - len(data))
         LOGGER.debug('write %s (and %i padding bytes)', ' '.join(format(i, '02x') for i in data), len(padding))
         self.device.write(data + padding)
+
+    def _write_colors(self, cid, mode, colors, sval):
+        mval, size_variant, speed_scale, mincolors, maxcolors = _COLOR_MODES[mode]
+        color_count = len(colors)
+        if maxcolors == 40:
+            raise NotImplementedError()
+        elif mode == 'wings':  # wings requires special handling
+            raise NotImplementedError()
+        else:
+            opcode = [0x2a, 0x04]
+            address = [cid, cid]
+            speed_value = _SPEED_VALUE[speed_scale][sval]
+            header = opcode + address + [mval] + speed_value
+            color = list(itertools.chain(*colors)) + [0, 0, 0] * (16 - color_count)
+            if 'marquee' in mode:
+                backwards_byte = 0x04
+            elif mode == 'starry-night' or 'moving-alternating' in mode:
+                backwards_byte = 0x01
+            else:
+                backwards_byte = 0x00
+            if 'backwards' in mode:
+                backwards_byte += 0x02
+            if mode == 'fading' or mode == 'pulse' or mode == 'breathing':
+                mode_related = 0x08
+            elif mode == 'tai-chi' or mode == 'water-cooler':
+                mode_related = 0x05
+            elif mode == 'loading':
+                mode_related = 0x04
+            else:
+                mode_related = 0x00
+            static_byte = _STATIC_VALUE[cid]
+            led_size = size_variant if mval == 0x03 or mval == 0x05 else 0x03
+            footer = [backwards_byte, color_count, mode_related, static_byte, led_size]
+            self._write(header + color + footer)

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -88,6 +88,7 @@ class KrakenThreeX(UsbHidDriver):
         return [
             ('Liquid temperature', msg[15] + msg[14] / 10, '°C'),
             ('Pump speed', msg[18] << 8 | msg[17], 'rpm'),
+            ('Pump speed', msg[19], '%'),
         ]
 
     def _read(self):
@@ -107,7 +108,6 @@ class KrakenThreeX(UsbHidDriver):
             if not parsers:
                 return
         assert False, f'missing messages (attempts={_MAX_READ_ATTEMPTS}, missing={len(parsers)})'
-
 
     def _write(self, data):
         padding = [0x0]*(_WRITE_LENGTH - len(data))

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -135,6 +135,7 @@ _ACCESSORY_NAMES = {
     0x05: "HUE 2 LED Strip 250 mm",
     0x06: "HUE 2 LED Strip 200 mm",
     0x08: "HUE 2 Cable Comb",
+    0x09: "HUE 2 Underglow 300 mm",
     0x0a: "HUE 2 Underglow 200 mm",
     0x0b: "AER RGB 2 120 mm",
     0x0c: "AER RGB 2 140 mm",
@@ -229,7 +230,6 @@ class KrakenThreeXDriver(UsbHidDriver):
         norm = normalize_profile(profile, _CRITICAL_TEMPERATURE)
         interp = [(interpolate_profile(norm, t)) for t in range(20, 60)]
         LOGGER.debug('setting pump curve: %s', [(num+20, duty) for (num, duty) in enumerate(interp)])
-        raise NotImplementedError()  # precaution
         self._write(header + interp)
 
     def set_fixed_speed(self, channel, duty, **kwargs):

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -68,7 +68,8 @@ class KrakenThreeX(UsbHidDriver):
         msg = self._read()
 
         return [
-            ('Liquid temperature', msg[14] / 256 + msg[15], '°C'),
+            ('Liquid temperature', msg[15] + msg[14] / 10, '°C'),
+            ('Pump speed', msg[18] << 8 | msg[17], 'rpm'),
         ]
 
     def _read(self):

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -1,4 +1,4 @@
-"""liquidctl driver for CoolIT Platinum coolers for Corsair.
+"""liquidctl driver for Kraken X3 devices from NZXT.
 
  Supported devices
  -----------------
@@ -10,14 +10,17 @@
  Supported features
  ------------------
 
-  - [ ] general monitoring
-  - [ ] pump speed control
-  - [ ] lighting control
+  - [✓] general monitoring
+  - [✓] pump speed control
+  - [✓] lighting control
+  - [ ] lighting control advanced - super-breathing, super-fixed, super-wave, wings, water-cooler
+  - [ ] pump speed curve ?
 
  ---
 
  liquidctl driver for Kraken X3 devices from NZXT.
  Copyright (C) 2020–2020  Jonas Malaco
+ Copyright (C) 2020–2020  Tom Frey
  Copyright (C) 2020–2020  each contribution's author
 
  This file is part of liquidctl.

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -267,7 +267,7 @@ class KrakenThreeXDriver(UsbHidDriver):
         mval, size_variant, speed_scale, mincolors, maxcolors = _COLOR_MODES[mode]
         color_count = len(colors)
         if 'super-fixed' == mode or 'super-breathing' == mode:
-            color = list(itertools.chain(*colors)) + [0xff, 0xff, 0xff] * (maxcolors - color_count)
+            color = list(itertools.chain(*colors)) + [0x00, 0x00, 0x00] * (maxcolors - color_count)
             speed_value = _SPEED_VALUE[speed_scale][sval]
             self._write([0x22, 0x10, cid, 0x00] + color)
             self._write([0x22, 0x11, cid, 0x00])

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -52,3 +52,27 @@ class KrakenThreeX(UsbHidDriver):
     SUPPORTED_DEVICES = [
         (0x1e71, 0x2007, None, 'NZXT Kraken X3 Pump (X53, X63 or X73) (experimental)', {})
     ]
+
+    def initialize(self, **kwargs):
+        """Initialize the device.
+
+        Aparently not required.
+        """
+        pass
+
+    def get_status(self, **kwargs):
+        """Get a status report.
+
+        Returns a list of `(property, value, unit)` tuples.
+        """
+        msg = self._read()
+
+        return [
+            ('Liquid temperature', msg[14] / 256 + msg[15], '°C'),
+        ]
+
+    def _read(self):
+        data = self.device.read(_READ_LENGTH)
+        self.device.release()
+        LOGGER.debug('received %s', ' '.join(format(i, '02x') for i in data))
+        return data

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -97,7 +97,7 @@ _COLOR_MODES = {
     'backwards-rainbow-pulse':              (0x0b, 0x00, 2, 0, 0),
     'loading':                              (0x10, 0x00, 8, 1, 1),
     'tai-chi':                              (0x0e, 0x00, 7, 1, 2),
-    # 'water-cooler':                         (0x0f, 0x00, 6, 0, 0),
+    'water-cooler':                         (0x0f, 0x00, 6, 2, 2),
 }
 _STATIC_VALUE = {
     0x02: 0x08,
@@ -261,7 +261,7 @@ class KrakenThreeX(UsbHidDriver):
     def _write_colors(self, cid, mode, colors, sval):
         mval, size_variant, speed_scale, mincolors, maxcolors = _COLOR_MODES[mode]
         color_count = len(colors)
-        if 'super-fixed' == mode or 'super-breathing':
+        if 'super-fixed' == mode or 'super-breathing' == mode:
             color = list(itertools.chain(*colors)) + [0xff, 0xff, 0xff] * (maxcolors - color_count)
             speed_value = _SPEED_VALUE[speed_scale][sval]
             self._write([0x22, 0x10, cid, 0x00] + color)
@@ -285,8 +285,11 @@ class KrakenThreeX(UsbHidDriver):
                 backwards_byte += 0x02
             if mode == 'fading' or mode == 'pulse' or mode == 'breathing':
                 mode_related = 0x08
-            elif mode == 'tai-chi' or mode == 'water-cooler':
+            elif mode == 'tai-chi':
                 mode_related = 0x05
+            elif mode == 'water-cooler':
+                mode_related = 0x05
+                color_count = 0x01
             elif mode == 'loading':
                 mode_related = 0x04
             else:

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -229,15 +229,13 @@ class KrakenThreeXDriver(UsbHidDriver):
         header = [0x72, 0x01, 0x00, 0x00]
         norm = normalize_profile(profile, _CRITICAL_TEMPERATURE)
         interp = [(interpolate_profile(norm, t)) for t in range(20, 60)]
-        LOGGER.debug('setting pump curve: %s', [(num+20, duty) for (num, duty) in enumerate(interp)])
+        LOGGER.debug('setting pump curve: %s', [(num + 20, duty) for (num, duty) in enumerate(interp)])
         self._write(header + interp)
 
     def set_fixed_speed(self, channel, duty, **kwargs):
         """Set channel to a fixed speed duty."""
-        if channel != 'pump':
-            assert False, 'kraken X3 devices only support changing pump speeds'
         duty = clamp(duty, 20, 100)
-        self._write([0x72, 0x01, 0x00, 0x00] + [duty] * 40)
+        self.set_speed_profile(channel, [(i, duty) for i in range(20, 60)])
         self.device.release()
 
     def _read(self):

--- a/liquidctl/driver/kraken_three_x.py
+++ b/liquidctl/driver/kraken_three_x.py
@@ -43,7 +43,7 @@ import logging
 import itertools
 
 from liquidctl.driver.usb import UsbHidDriver
-from liquidctl.util import normalize_profile, interpolate_profile
+from liquidctl.util import normalize_profile, interpolate_profile, clamp
 
 LOGGER = logging.getLogger(__name__)
 
@@ -148,7 +148,7 @@ class KrakenThreeXDriver(UsbHidDriver):
     """liquidctl driver for Kraken X3 devices from NZXT."""
 
     SUPPORTED_DEVICES = [
-        (0x1e71, 0x2007, None, 'NZXT Kraken X3 Pump (X53, X63 or X73) (experimental)', {})
+        (0x1e71, 0x2007, None, 'NZXT Kraken X (X53, X63 or X73) (experimental)', {})
     ]
 
     def initialize(self, **kwargs):
@@ -236,9 +236,7 @@ class KrakenThreeXDriver(UsbHidDriver):
         """Set channel to a fixed speed duty."""
         if channel != 'pump':
             assert False, 'kraken X3 devices only support changing pump speeds'
-        if duty < 20 or duty > 100:
-            assert False, f'invalid duty value: {duty}. must be between 20 and 100!'
-
+        duty = clamp(duty, 20, 100)
         self._write([0x72, 0x01, 0x00, 0x00] + [duty] * 40)
         self.device.release()
 


### PR DESCRIPTION
Work in progress; will eventually add support for the following coolers:

* NZXT Kraken X53
* NZXT Kraken X63
* NZXT Kraken X73

Related: #78 ("Support for NZXT Kraken X53, X63 and X73")

Currently only tested on Kraken X73.

**Todo:**
- [x] general monitoring
- [x] pump speed control
- [x] lighting control
- [x] lighting control advanced - super-breathing, super-fixed, wings, water-cooler
- [x] custom pump speed curve
- [ ] general code improvements (see comments below)
- [ ] lighting control advanced - additional accessories
