### PR TITLE
Fix user HOME path for macOS

### DIFF
--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -23,7 +23,7 @@ def get_runtime_dirs(appname='liquidctl'):
     if sys.platform == 'win32':
         dirs = [os.path.join(os.getenv('TEMP'), appname)]
     elif sys.platform == 'darwin':
-        dirs = [os.path.join('~/Library/Caches', appname)]
+        dirs = [os.path.expanduser(os.path.join('~/Library/Caches', appname))]
     elif sys.platform == 'linux':
         # threat all other platforms as *nix and conform to XDG basedir spec
         dirs = []

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -56,12 +56,10 @@ class _FilesystemBackend:
         self._read_dirs = [os.path.join(x, *key_prefixes) for x in get_runtime_dirs()]
         self._write_dir = self._read_dirs[0]
         os.makedirs(self._write_dir, exist_ok=True)
-        if XDG_RUNTIME_DIR and os.path.commonpath([XDG_RUNTIME_DIR, self._write_dir]):
+        if sys.platform == 'linux':
             # set the sticky bit to prevent removal during cleanup
             os.chmod(self._write_dir, 0o1700)
-            LOGGER.debug('data in %s (within XDG_RUNTIME_DIR)', self._write_dir)
-        else:
-            LOGGER.debug('data in %s', self._write_dir)
+        LOGGER.debug('data in %s', self._write_dir)
 
     def load(self, key):
         for base in self._read_dirs:


### PR DESCRIPTION
Currently the cache folder for macOS is `~/Library/Caches` but the `~` is not expanded to the current user directory. 

If I open a terminal in my HOME folder and run `liquidctl status` it generates `~/Library/Caches/liquidctl/...` inside my HOME directory, i.e. `/Users/<username>/~/Library/Caches`. If I now change the directory in the terminal to `~/Downloads` and run liquidctl again, it creates a directory `/Users/<username>/Downloads/~/Library/Caches/liquidctl/...`.

To fix this behaviour, `os.path.expanduser(path)` is used to expand the `~` symbol to it's absolute path. Now the cache directory will be in the correct place.