### PR TITLE
Faulty "too many colors message"

### DIFF
--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -130,6 +130,11 @@ class HydroPlatinum(UsbHidDriver):
             ('led', 'fixed'): 1,
             ('led', 'off'): 0,
         }
+        self._maxcolors = {
+            ('led', 'super-fixed'): self._led_count,
+            ('led', 'fixed'): 1,
+            ('led', 'off'): 0,
+        }
         # the following fields are only initialized in connect()
         self._data = None
         self._sequence = None
@@ -268,13 +273,15 @@ class HydroPlatinum(UsbHidDriver):
     def _check_color_args(self, channel, mode, colors):
         try:
             mincolors = self._mincolors[(channel, mode)]
+            maxcolors = self._maxcolors[(channel, mode}]
         except KeyError:
             raise ValueError(f'Unsupported (channel, mode) pair, should be one of: {_quoted(*self._mincolors)}')
         if len(colors) < mincolors:
             raise ValueError(f'At least {mincolors} required for {_quoted((channel, mode))}')
-        if len(colors) > mincolors:
-            LOGGER.warning('too many colors, dropping to %d', mincolors)
-        return mincolors
+        if len(colors) > maxcolors:
+            LOGGER.warning('too many colors, dropping to %d', maxcolors)
+            return maxcolors
+        return len(colors)
 
     def _get_hw_fan_channels(self, channel):
         channel = channel.lower()

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -273,7 +273,7 @@ class HydroPlatinum(UsbHidDriver):
     def _check_color_args(self, channel, mode, colors):
         try:
             mincolors = self._mincolors[(channel, mode)]
-            maxcolors = self._maxcolors[(channel, mode}]
+            maxcolors = self._maxcolors[(channel, mode)]
         except KeyError:
             raise ValueError(f'Unsupported (channel, mode) pair, should be one of: {_quoted(*self._mincolors)}')
         if len(colors) < mincolors:


### PR DESCRIPTION
When running the command  `liquidctl set led color super-fixed FF0000 00FF00 0000FF` with a Corsair H100i platinum cooler it gave the error message `too many colors, dropping to 1` I believed this to be in error as the documentation and the code for that command allows up to a max of 24 colors to be given.

I have resolved this misleading error message by adding a `maxcolors` check and giving that message when the number given exceed that amount. I am not sure but this may also be an issue for other coolers but I only checked this one. 



Tested using  version 1.4.1 built from source on Fedora31.
