### PR TITLE
Product ID parsing fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Lighting is controlled in a similar fashion.  The specific documentation for eac
 
 When configuring lighting effects, colors can be specified in different representations and formats:
 
- - as an implicit hexadecimal RGB triple: e.g. `ff7f3f`
+ - as an implicit hexadecimal RGB triple, either with or without the `0x` prefix: e.g. `ff7f3f`
  - as an explicit RGB triple: e.g. `rgb(255, 127, 63)`
  - as a HSV (hue‑saturation‑value) triple: e.g. `hsv(20, 75, 100)`
     * hue ∊ [0, 360] (degrees); saturation, value ∊ [0, 100] (percent)

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -80,7 +80,7 @@ lighting modes.  Supported lighting modes and additional options vary by device
 and are listed in later sections of this manual.  Each color can be specified
 as:
 .IP \(bu
-hexadecimal RGB without prefix: \fIff7f3f\fR;
+hexadecimal RGB with or without prefix '0x': \fIff7f3f\fR;
 .IP \(bu
 decimal RGB triple, R,G,B ∊ [0, 255]: \fIrgb(255,127,63)\fR;
 .IP \(bu

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -13,9 +13,9 @@ Usage:
 Device selection options (see: list -v):
   -m, --match <substring>     Filter devices by description substring
   -n, --pick <number>         Pick among many results for a given filter
-  --vendor <id>               Filter devices by vendor id
-  --product <id>              Filter devices by product id
-  --release <number>          Filter devices by release number
+  --vendor <id>               Filter devices by vendor id (hex value)
+  --product <id>              Filter devices by product id (hex value)
+  --release <number>          Filter devices by release number (hex value)
   --serial <number>           Filter devices by serial number
   --bus <bus>                 Filter devices by bus
   --address <address>         Filter devices by address in bus
@@ -83,9 +83,9 @@ from liquidctl.version import __version__
 #  - have no default value in the CLI level (not forwarded unless explicitly set);
 #  - and avoid unintentional conflicts with target function arguments
 _PARSE_ARG = {
-    '--vendor': lambda x: int(x, 0),
-    '--product': lambda x: int(x, 0),
-    '--release': lambda x: int(x, 0),
+    '--vendor': lambda x: int(x, 16),
+    '--product': lambda x: int(x, 16),
+    '--release': lambda x: int(x, 16),
     '--serial': str,
     '--bus': str,
     '--address': str,

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -216,12 +216,14 @@ def color_from_str(x):
 
     The input string can be encoded in several formats:
 
-     - ffffff: hexadecimal RGB implicit tuple
+     - ffffff: hexadecimal RGB implicit tuple (with or without the prefix '0x')
      - rgb(255, 255, 255): explicit RGB, R,G,B ∊ [0, 255]
      - hsv(360, 100, 100): explicit HSV, H ∊ [0, 360], SV ∊ [0, 100]
      - hsl(360, 100, 100): explicit HSL, H ∊ [0, 360], SV ∊ [0, 100]
 
     >>> color_from_str('fF7f3f')
+    [255, 127, 63]
+    >>> color_from_str('0xfF7f3f')
     [255, 127, 63]
     >>> color_from_str('Rgb(255, 127, 63)')
     [255, 127, 63]
@@ -278,5 +280,7 @@ def color_from_str(x):
         return list(map(lambda b: round(b*255), colorsys.hls_to_rgb(h/360, l/100, s/100)))
     elif len(x) == 6:
         return list(bytes.fromhex(x))
+    elif len(x) == 8 and x[0:2] == '0x':
+        return list(bytes.fromhex(x[2:]))
     else:
         raise ValueError(f'Cannot parse color: {x}')

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -225,6 +225,8 @@ def color_from_str(x):
     [255, 127, 63]
     >>> color_from_str('0xfF7f3f')
     [255, 127, 63]
+    >>> color_from_str('0XfF7f3f')
+    [255, 127, 63]
     >>> color_from_str('Rgb(255, 127, 63)')
     [255, 127, 63]
     >>> color_from_str('Hsv(20, 75, 100)')
@@ -236,6 +238,10 @@ def color_from_str(x):
     Traceback (most recent call last):
         ...
     ValueError: Cannot parse color: fF7f3f1f
+    >>> color_from_str('0bff00ff')
+    Traceback (most recent call last):
+        ...
+    ValueError: Cannot parse color: 0bff00ff
     >>> color_from_str('rgb()')
     Traceback (most recent call last):
         ...

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -280,7 +280,7 @@ def color_from_str(x):
         return list(map(lambda b: round(b*255), colorsys.hls_to_rgb(h/360, l/100, s/100)))
     elif len(x) == 6:
         return list(bytes.fromhex(x))
-    elif len(x) == 8 and x[0:2] == '0x':
+    elif len(x) == 8 and (x[0:2] == '0x' or x[0:2] == '0X'):
         return list(bytes.fromhex(x[2:]))
     else:
         raise ValueError(f'Cannot parse color: {x}')


### PR DESCRIPTION
Fix for issue #186. 

- Modified the  the `color_from_str()` function to accept hex color values with the prefixes 0x` or `0X` or without the prefix. 
- Also added 3 more doctests to ensure  verify that it behaves correctly.
- Modified the list of supported color options to show this change
- corrected the parsing of the `--vendor`, `--product`, and `--release` flags to only accept hex values either with or without the `0x` or `0X` prefixes. 