### PR TITLE
Status firmware

### DIFF
--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -176,12 +176,15 @@ class HydroPlatinum(UsbHidDriver):
         """
 
         res = self._send_command(_FEATURE_COOLING, _CMD_GET_STATUS)
+
+        fw_version = (res[2] >> 4, res[2] & 0xf, res[3])
         assert len(self._fan_names) == 2, f'cannot yet parse with {len(self._fan_names)} fans'
         return [
             ('Liquid temperature', res[8] + res[7] / 255, '°C'),
             ('Fan 1 speed', u16le_from(res, offset=15), 'rpm'),
             ('Fan 2 speed', u16le_from(res, offset=22), 'rpm'),
             ('Pump speed', u16le_from(res, offset=29), 'rpm'),
+            ('Firmware version', '%d.%d.%d' % fw_version, ''),
         ]
 
     def set_fixed_speed(self, channel, duty, **kwargs):


### PR DESCRIPTION
Added the device firmware version to the `get_status()` response for the Corsair hydro series coolers. I added this because a number of the other coolers include the firmware version in the status message. The tests were also updated accordingly