### PR TITLE
Fixed 'magic led message' sending with invalid channel/mode combinations for Corsair H100i Platinum

### DIFF
--- a/tests/test_hydro_platinum.py
+++ b/tests/test_hydro_platinum.py
@@ -196,6 +196,9 @@ class HydroPlatinumTestCase(unittest.TestCase):
         self.assertRaises(Exception, self.device.set_color, channel='invalid',
                           mode='off', colors=[])
 
+        self.assertEqual(len(self.mock_hid.sent), 0)
+
+
     def test_short_enough_storage_path(self):
         assert len(self.device._data._backend._write_dir) < _WIN_MAX_PATH;
         assert self.device._data._backend._write_dir.endswith('3142')


### PR DESCRIPTION
From the conversation in #194, it was noticed that I made a mistake in the implementation and the magic command was being sent for invalid `(channel, mode)` combinations. This has been fixed by sending the magic packets later. Also added a test to confirm that when an invalid mode is specified the command is not sent to the device. 
