### PR TITLE
Update liquidctl.bash

### DIFF
--- a/extra/completions/liquidctl.bash
+++ b/extra/completions/liquidctl.bash
@@ -78,6 +78,7 @@ _liquidctl_main() {
     --help
     --single-12v-ocp
     --legacy-690lc
+    --non-volatile
     "
 
     local options_with_args="


### PR DESCRIPTION
Added the `--non-volatile` bash completion option that got missed in the 2 smbus PR's